### PR TITLE
Google IAP authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cat <monitoring.log> | grep -v "#" | cromwell-cli gce monitoring -r <cpu|mem|dis
 ### Example: Cromwell behind Google Indentity Aware Proxy
 
 ```bash
-TOKEN=$(gcloud auth print-identity-token --impersonate-service-account <your@service-account.iam.gserviceaccount.com> --audiences <oauth-client-id.googleusercontent.com> --include-email)
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/google/service-account.json
 HOST="https://your-cromwell.dev"
-cromwell-cli --host "${HOST}" --token "${TOKEN}" query
+AUDIENCE="Expected audience"
+cromwell-cli --host "${HOST}" --iap "${AUDIENCE}" query
 ```

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/urfave/cli/v2 v2.2.0
 	go.uber.org/zap v1.15.0
+	google.golang.org/api v0.32.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/install.sh
+++ b/install.sh
@@ -149,7 +149,7 @@ main() {
 
     prefix="${1}"
     cli_base_url="https://github.com/lmtani/cromwell-cli/releases/download"
-    version="0.8.1"
+    version="0.8.2"
     print_message "== Install prefix set to ${prefix}" "info"
 
     cli_arch="$(determine_arch)"

--- a/main.go
+++ b/main.go
@@ -38,10 +38,9 @@ func main() {
 		Usage: "Command line interface for Cromwell Server",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "token",
-				Aliases:  []string{"t"},
+				Name:     "iap",
 				Required: false,
-				Usage:    "Bearer token to be included in HTTP requsts",
+				Usage:    "Uses your defauld Google Credentials to obtains an access token.",
 			},
 			&cli.StringFlag{
 				Name:  "host",
@@ -50,7 +49,7 @@ func main() {
 			},
 		},
 		Before: func(c *cli.Context) error {
-			cromwellClient := commands.New(c.String("host"), c.String("token"))
+			cromwellClient := commands.New(c.String("host"), c.String("iap"))
 			c.Context = context.WithValue(c.Context, keyCromwell, cromwellClient)
 			return nil
 		},

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 			&cli.StringFlag{
 				Name:     "iap",
 				Required: false,
-				Usage:    "Uses your defauld Google Credentials to obtains an access token.",
+				Usage:    "Uses your defauld Google Credentials to obtains an access token to this audience.",
 			},
 			&cli.StringFlag{
 				Name:  "host",


### PR DESCRIPTION
This PR enables cromwell-cli to use env var `GOOGLE_APPLICATION_CREDENTIALS` to obtains an id token that allows communication with a Cromwell server behind Google IAP.