### PR TITLE
✨ Use submission date to limit workflow query

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,15 +1,38 @@
 package commands
 
 import (
+	"log"
+	"os"
+
+	"github.com/lmtani/cromwell-cli/internal/prompt"
 	"github.com/lmtani/cromwell-cli/pkg/cromwell"
 	"github.com/lmtani/cromwell-cli/pkg/output"
 )
 
-type Commands struct {
-	CromwellClient *cromwell.Client
-	writer         output.IWriter
+var (
+	defaultLogger = log.New(os.Stderr, "", log.LstdFlags)
+	defaultClient = cromwell.Default()
+	defaultWriter = output.NewColoredWriter()
+	defaultPrompt = prompt.New()
+)
+
+type Prompt interface {
+	SelectByKey(taskOptions []string) (string, error)
+	SelectByIndex(t prompt.TemplateOptions, sfn func(input string, index int) bool, items interface{}) (int, error)
 }
 
-func New(c *cromwell.Client, w output.IWriter) Commands {
-	return Commands{CromwellClient: c, writer: w}
+type Commands struct {
+	CromwellClient cromwell.Client
+	Logger         *log.Logger
+	Prompt         Prompt
+	Writer         output.IWriter
+}
+
+func New() *Commands {
+	return &Commands{
+		CromwellClient: defaultClient,
+		Logger:         defaultLogger,
+		Prompt:         defaultPrompt,
+		Writer:         defaultWriter,
+	}
 }

--- a/commands/cost.go
+++ b/commands/cost.go
@@ -26,8 +26,8 @@ func (c *Commands) ResourcesUsed(operation string) error {
 	}
 	var rtr = ResourceTableResponse{Total: total}
 	output.NewTable(os.Stdout).Render(rtr)
-	c.writer.Accent(fmt.Sprintf("- Tasks with cache hit: %d", total.CachedCalls))
-	c.writer.Accent(fmt.Sprintf("- Total time with running VMs: %.0fh", total.TotalTime.Hours()))
+	c.Writer.Accent(fmt.Sprintf("- Tasks with cache hit: %d", total.CachedCalls))
+	c.Writer.Accent(fmt.Sprintf("- Total time with running VMs: %.0fh", total.TotalTime.Hours()))
 	return nil
 }
 

--- a/commands/cost_test.go
+++ b/commands/cost_test.go
@@ -26,10 +26,11 @@ func (w Uncolored) Error(s string) {
 	fmt.Println(s)
 }
 
-func buildTestCommands(h, i string) Commands {
-	c := cromwell.New(h, i)
-	w := NewUncolored()
-	cmds := New(c, w)
+func buildTestCommands(h, i, prompt_key string, prompt_int int) *Commands {
+	cmds := New()
+	cmds.CromwellClient = cromwell.New(h, i)
+	cmds.Writer = NewUncolored()
+	cmds.Prompt = NewForTests(prompt_key, prompt_int)
 	return cmds
 }
 
@@ -45,7 +46,7 @@ func ExampleCommands_ResourcesUsed() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/metadata", string(content))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err = cmds.ResourcesUsed(operation)
 	if err != nil {
 		log.Print(err)

--- a/commands/get.go
+++ b/commands/get.go
@@ -21,7 +21,7 @@ func (c *Commands) QueryWorkflow(name string) error {
 	}
 	var qtr = QueryTableResponse(resp)
 	output.NewTable(os.Stdout).Render(qtr)
-	c.writer.Accent(fmt.Sprintf("- Found %d workflows", resp.TotalResultsCount))
+	c.Writer.Accent(fmt.Sprintf("- Found %d workflows", resp.TotalResultsCount))
 	return err
 }
 

--- a/commands/get.go
+++ b/commands/get.go
@@ -9,11 +9,17 @@ import (
 	"github.com/lmtani/cromwell-cli/pkg/output"
 )
 
-func (c *Commands) QueryWorkflow(name string) error {
+func (c *Commands) QueryWorkflow(name string, days time.Duration) error {
+	date := time.Now().Add(-time.Hour * 24 * days)
 	params := url.Values{}
 	if name != "" {
 		params.Add("name", name)
 	}
+	if days != 0 {
+		c.Writer.Accent(fmt.Sprintf("Querying workflows from %s until now", date.Format(time.Stamp)))
+		params.Add("submission", date.Format("2006-01-02T00:00:00.000Z"))
+	}
+
 	params.Add("includeSubworkflows", "false")
 	resp, err := c.CromwellClient.Query(params)
 	if err != nil {

--- a/commands/get_test.go
+++ b/commands/get_test.go
@@ -25,7 +25,7 @@ func ExampleCommands_QueryWorkflow() {
 	defer ts.Close()
 
 	cmds := buildTestCommands(ts.URL, "", "", 0)
-	err := cmds.QueryWorkflow("wf")
+	err := cmds.QueryWorkflow("wf", 0)
 	if err != nil {
 		log.Print(err)
 	}

--- a/commands/get_test.go
+++ b/commands/get_test.go
@@ -24,7 +24,7 @@ func ExampleCommands_QueryWorkflow() {
 	ts := buildTestServer("/api/workflows/v1/query", `{"Results": [{"id":"aaa", "name": "wf", "status": "Running", "submission": "2021-03-22T13:06:42.626Z", "start": "2021-03-22T13:06:42.626Z", "end": "2021-03-22T13:06:42.626Z", "metadataarchivestatus": "archived"}], "TotalResultsCount": 1}`)
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.QueryWorkflow("wf")
 	if err != nil {
 		log.Print(err)

--- a/commands/inputs_test.go
+++ b/commands/inputs_test.go
@@ -21,7 +21,7 @@ func ExampleCommands_Inputs() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/metadata", string(content))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err = cmds.Inputs(operation)
 	if err != nil {
 		log.Print(err)
@@ -48,7 +48,7 @@ func TestInputsHttpError(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.Inputs(operation)
 	if err == nil {
 		t.Error("Not found error expected, nil returned")

--- a/commands/kill.go
+++ b/commands/kill.go
@@ -9,6 +9,6 @@ func (c *Commands) KillWorkflow(operation string) error {
 	if err != nil {
 		return err
 	}
-	c.writer.Accent(fmt.Sprintf("Operation=%s, Status=%s", resp.ID, resp.Status))
+	c.Writer.Accent(fmt.Sprintf("Operation=%s, Status=%s", resp.ID, resp.Status))
 	return nil
 }

--- a/commands/kill_test.go
+++ b/commands/kill_test.go
@@ -12,7 +12,7 @@ func ExampleKill() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/abort", `{"id": "aaa-bbb-ccc", "status": "aborting"}`)
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.KillWorkflow(operation)
 	if err != nil {
 		log.Print(err)
@@ -36,7 +36,7 @@ func TestKillHttpError(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.KillWorkflow(operation)
 	if err == nil {
 		t.Error("Not found error expected, nil returned")

--- a/commands/metadata.go
+++ b/commands/metadata.go
@@ -26,11 +26,11 @@ func (c *Commands) MetadataWorkflow(operation string) error {
 	var mtr = MetadataTableResponse{Metadata: resp}
 	output.NewTable(os.Stdout).Render(mtr)
 	if len(resp.Failures) > 0 {
-		c.writer.Error(hasFailureMsg(resp.Failures))
-		recursiveFailureParse(resp.Failures, c.writer)
+		c.Writer.Error(hasFailureMsg(resp.Failures))
+		recursiveFailureParse(resp.Failures, c.Writer)
 	}
 
-	showCustomOptions(resp.SubmittedFiles, c.writer)
+	showCustomOptions(resp.SubmittedFiles, c.Writer)
 	return nil
 }
 

--- a/commands/metadata_test.go
+++ b/commands/metadata_test.go
@@ -18,7 +18,7 @@ func ExampleCommands_MetadataWorkflow() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/metadata", string(content))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err = cmds.MetadataWorkflow(operation)
 	if err != nil {
 		log.Print(err)
@@ -47,7 +47,7 @@ func ExampleCommands_MetadataWorkflow_second() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/metadata", string(content))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err = cmds.MetadataWorkflow(operation)
 	if err != nil {
 		log.Print(err)

--- a/commands/navigate_test.go
+++ b/commands/navigate_test.go
@@ -21,8 +21,8 @@ func (p PromptForTests) SelectByIndex(t prompt.TemplateOptions, sfn func(input s
 	return p.byIndexReturn, nil
 }
 
-func NewForTests(byKey string, byIndex int) PromptForTests {
-	return PromptForTests{
+func NewForTests(byKey string, byIndex int) *PromptForTests {
+	return &PromptForTests{
 		byKeyReturn: byKey, byIndexReturn: byIndex,
 	}
 }
@@ -39,9 +39,8 @@ func ExampleCommands_Navigate() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/metadata", string(content))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
-	prompt := NewForTests("SayGoodbye", 1)
-	err = cmds.Navigate(prompt, operation)
+	cmds := buildTestCommands(ts.URL, "", "SayGoodbye", 1)
+	err = cmds.Navigate(operation)
 	if err != nil {
 		log.Print(err)
 	}
@@ -72,9 +71,8 @@ func ExampleCommands_Navigate_second() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/metadata", string(content))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
-	prompt := NewForTests("RunHelloWorkflows", 1)
-	err = cmds.Navigate(prompt, operation)
+	cmds := buildTestCommands(ts.URL, "", "RunHelloWorkflows", 1)
+	err = cmds.Navigate(operation)
 	if err != nil {
 		log.Print(err)
 	}

--- a/commands/outputs_test.go
+++ b/commands/outputs_test.go
@@ -13,7 +13,7 @@ func ExampleCommands_OutputsWorkflow() {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/outputs", `{"id": "aaa-bbb-ccc", "outputs": {"output_path": "/path/to/output.txt"}}`)
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.OutputsWorkflow(operation)
 	if err != nil {
 		log.Print(err)
@@ -39,7 +39,7 @@ func TestOutputsHttpError(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.OutputsWorkflow(operation)
 	if err == nil {
 		t.Error("Not found error expected, nil returned")
@@ -52,7 +52,7 @@ func TestOutputsReturnError(t *testing.T) {
 	ts := buildTestServer("/api/workflows/v1/"+operation+"/outputs", `improbable-situation`)
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.OutputsWorkflow(operation)
 	if err != nil {
 		log.Print(err)

--- a/commands/submit.go
+++ b/commands/submit.go
@@ -16,6 +16,6 @@ func (c *Commands) SubmitWorkflow(wdl, inputs, dependencies, options string) err
 	if err != nil {
 		return err
 	}
-	c.writer.Accent(fmt.Sprintf("🐖 Operation= %s , Status=%s", resp.ID, resp.Status))
+	c.Writer.Accent(fmt.Sprintf("🐖 Operation= %s , Status=%s", resp.ID, resp.Status))
 	return nil
 }

--- a/commands/submit_test.go
+++ b/commands/submit_test.go
@@ -12,7 +12,7 @@ func ExampleCommands_SubmitWorkflow() {
 	wdlPath := "../sample/wf.wdl"
 	inputsPath := "../sample/wf.inputs.json"
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.SubmitWorkflow(wdlPath, inputsPath, wdlPath, inputsPath)
 	if err != nil {
 		log.Print(err)

--- a/commands/wait.go
+++ b/commands/wait.go
@@ -22,7 +22,7 @@ func (c *Commands) Wait(operation string, sleep int, alarm bool) error {
 		if err != nil {
 			return err
 		}
-		c.writer.Accent(fmt.Sprintf("Status=%s\n", resp.Status))
+		c.Writer.Accent(fmt.Sprintf("Status=%s\n", resp.Status))
 		status = resp.Status
 	}
 

--- a/commands/wait_test.go
+++ b/commands/wait_test.go
@@ -29,7 +29,7 @@ func ExampleCommands_Wait() {
 	ts := buildTestServerMutable("/api/workflows/v1/" + operation + "/status")
 	defer ts.Close()
 
-	cmds := buildTestCommands(ts.URL, "")
+	cmds := buildTestCommands(ts.URL, "", "", 0)
 	err := cmds.Wait(operation, 1, false)
 	if err != nil {
 		log.Printf("Error: %#v", err)

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -11,8 +11,8 @@ type IPrompt interface {
 	SelectByIndex(t TemplateOptions, sfn func(input string, index int) bool, items interface{}) (int, error)
 }
 
-func New() Prompt {
-	return Prompt{}
+func New() *Prompt {
+	return &Prompt{}
 }
 
 type Searcher func(input string, index int) bool

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 				Usage:   "Query workflows",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Required: false, Value: "", Usage: "Filter by workflow name"},
-					&cli.Int64Flag{Name: "days", Aliases: []string{"d"}, Required: false, Value: 7, Usage: "Show workflows from the last N days"},
+					&cli.Int64Flag{Name: "days", Aliases: []string{"d"}, Required: false, Value: 7, Usage: "Show workflows from the last N days. Use 0 to show all workflows"},
 				},
 				Action: func(c *cli.Context) error {
 					return cmds.QueryWorkflow(c.String("name"), time.Duration(c.Int64("days")))

--- a/main.go
+++ b/main.go
@@ -6,19 +6,13 @@ import (
 
 	"github.com/google/martian/log"
 	"github.com/lmtani/cromwell-cli/commands"
-	"github.com/lmtani/cromwell-cli/internal/prompt"
-	"github.com/lmtani/cromwell-cli/pkg/cromwell"
-	"github.com/lmtani/cromwell-cli/pkg/output"
 	"github.com/urfave/cli/v2"
 )
 
 var Version = "development"
 
 func main() {
-	cromwellClient := cromwell.Default()
-	writer := output.NewColoredWriter()
-	prompt := prompt.New()
-	cmds := commands.New(cromwellClient, writer)
+	cmds := commands.New()
 
 	app := &cli.App{
 		Name:  "cromwell-cli",
@@ -36,7 +30,7 @@ func main() {
 			},
 		},
 		Before: func(c *cli.Context) error {
-			cromwellClient.Setup(c.String("host"), c.String("iap"))
+			cmds.CromwellClient.Setup(c.String("host"), c.String("iap"))
 			return nil
 		},
 		Commands: []*cli.Command{
@@ -139,7 +133,7 @@ func main() {
 					&cli.StringFlag{Name: "operation", Aliases: []string{"o"}, Required: true},
 				},
 				Action: func(c *cli.Context) error {
-					return cmds.Navigate(prompt, c.String("operation"))
+					return cmds.Navigate(c.String("operation"))
 				},
 			},
 			{

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/martian/log"
 	"github.com/lmtani/cromwell-cli/commands"
@@ -48,10 +49,11 @@ func main() {
 				Aliases: []string{"q"},
 				Usage:   "Query workflows",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Required: false},
+					&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Required: false, Value: "", Usage: "Filter by workflow name"},
+					&cli.Int64Flag{Name: "days", Aliases: []string{"d"}, Required: false, Value: 7, Usage: "Show workflows from the last N days"},
 				},
 				Action: func(c *cli.Context) error {
-					return cmds.QueryWorkflow(c.String("name"))
+					return cmds.QueryWorkflow(c.String("name"), time.Duration(c.Int64("days")))
 				},
 			},
 			{

--- a/pkg/cromwell/client.go
+++ b/pkg/cromwell/client.go
@@ -18,12 +18,12 @@ type Client struct {
 	Iap  string
 }
 
-func New(h, t string) *Client {
-	return &Client{Host: h, Iap: t}
+func New(h, t string) Client {
+	return Client{Host: h, Iap: t}
 }
 
-func Default() *Client {
-	return &Client{Host: "http://127.0.0.1:8000", Iap: ""}
+func Default() Client {
+	return Client{Host: "http://127.0.0.1:8000", Iap: ""}
 }
 
 func (c *Client) Setup(h, t string) {

--- a/pkg/output/writer.go
+++ b/pkg/output/writer.go
@@ -14,8 +14,8 @@ type IWriter interface {
 	Error(string)
 }
 
-func NewColoredWriter() ColoredWriter {
-	return ColoredWriter{}
+func NewColoredWriter() *ColoredWriter {
+	return &ColoredWriter{}
 }
 
 func (w ColoredWriter) Primary(s string) {


### PR DESCRIPTION
There are servers with a lot of workflows in their databases. It is a problem when querying for all of them.

In this PR, we add a parameter to limit the query by using the workflow's submission date.
