### PR TITLE
fix: typos and deprecated ioutil.ReadFile

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func CLI(args []string, version string) int {
+func CLI(version string) int {
 	cmds := commands.New()
 
 	app := &cli.App{
@@ -19,7 +20,7 @@ func CLI(args []string, version string) int {
 			&cli.StringFlag{
 				Name:     "iap",
 				Required: false,
-				Usage:    "Uses your defauld Google Credentials to obtains an access token to this audience.",
+				Usage:    "Uses your default Google Credentials to obtains an access token to this audience.",
 			},
 			&cli.StringFlag{
 				Name:  "host",
@@ -157,7 +158,7 @@ func CLI(args []string, version string) int {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "Runtime error: %v\n", err)
+		log.Printf("Runtime error: %v\n", err)
 		return 1
 	}
 	return 0

--- a/internal/commands/cost.go
+++ b/internal/commands/cost.go
@@ -113,7 +113,7 @@ func iterateOverElement(call cromwell.CallItem) (cromwell.ParsedCallAttributes, 
 func parseDisc(r cromwell.RuntimeAttributes) (float64, string, error) {
 	workDisk := strings.Fields(r.Disks)
 	if len(workDisk) == 0 {
-		return 0, "", fmt.Errorf("No disks, found: %#v", r.Disks)
+		return 0, "", fmt.Errorf("no disks, found: %#v", r.Disks)
 	}
 	diskSize := workDisk[1]
 	diskType := workDisk[2]
@@ -129,11 +129,11 @@ func parseDisc(r cromwell.RuntimeAttributes) (float64, string, error) {
 }
 
 func parseMemory(r cromwell.RuntimeAttributes) (float64, error) {
-	memmory := strings.Fields(r.Memory)
-	if len(memmory) == 0 {
-		return 0, fmt.Errorf("No memory, found: %#v", r.Memory)
+	memory := strings.Fields(r.Memory)
+	if len(memory) == 0 {
+		return 0, fmt.Errorf("no memory, found: %#v", r.Memory)
 	}
-	size, err := strconv.ParseFloat(memmory[0], 4)
+	size, err := strconv.ParseFloat(memory[0], 4)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/commands/cost_test.go
+++ b/internal/commands/cost_test.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -10,12 +10,12 @@ import (
 )
 
 func TestCost(t *testing.T) {
-	file, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata.json")
 	if err != nil {
 		t.Fatal(err)
 	}
 	meta := cromwell.MetadataResponse{}
-	err = json.Unmarshal(file, &meta)
+	err = json.Unmarshal(content, &meta)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestParseDisk(t *testing.T) {
 		expectedType   string
 		expectedErr    string
 	}{
-		{runtime: r1, expectedAmount: 0, expectedType: "", expectedErr: "No disks, found:"},
+		{runtime: r1, expectedAmount: 0, expectedType: "", expectedErr: "no disks, found:"},
 		{runtime: r2, expectedAmount: 0, expectedType: "", expectedErr: "strconv.ParseFloat: parsing"},
 	}
 	for i, test := range tt {
@@ -143,7 +143,7 @@ func TestParseMemory(t *testing.T) {
 		expectedErr    string
 	}{
 		{runtime: r1, expectedAmount: 2, expectedErr: ""},
-		{runtime: r2, expectedAmount: 0, expectedErr: "No memory, found:"},
+		{runtime: r2, expectedAmount: 0, expectedErr: "no memory, found:"},
 		{runtime: r3, expectedAmount: 0, expectedErr: "strconv.ParseFloat: parsing"},
 	}
 	for i, test := range tt {

--- a/internal/commands/examples_test.go
+++ b/internal/commands/examples_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -14,11 +13,11 @@ import (
 	"github.com/lmtani/cromwell-cli/pkg/output"
 )
 
-func BuildTestCommands(h, i, prompt_key string, prompt_int int) *Commands {
+func BuildTestCommands(h, i, promptKey string, promptInt int) *Commands {
 	cmds := New()
 	cmds.CromwellClient = cromwell.New(h, i)
 	cmds.Writer = output.NewColoredWriter(os.Stdout)
-	cmds.Prompt = NewForTests(prompt_key, prompt_int)
+	cmds.Prompt = NewForTests(promptKey, promptInt)
 	return cmds
 }
 
@@ -89,9 +88,9 @@ func ExampleCommands_QueryWorkflow() {
 
 func ExampleCommands_Inputs() {
 	// Read metadata mock
-	content, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata.json")
 	if err != nil {
-		fmt.Print("Coult no read metadata mock file metadata.json")
+		fmt.Print("Could no read metadata mock file metadata.json")
 	}
 
 	// Mock http server
@@ -127,7 +126,7 @@ func ExampleCommands_KillWorkflow() {
 
 func ExampleCommands_Navigate() {
 	// Mock http server
-	content, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata.json")
 	if err != nil {
 		fmt.Print("Coult no read metadata mock file metadata.json")
 	}
@@ -159,7 +158,7 @@ func ExampleCommands_Navigate() {
 
 func ExampleCommands_Navigate_second() {
 	// Mock http server
-	content, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata.json")
 	if err != nil {
 		fmt.Print("Coult no read metadata mock file metadata.json")
 	}
@@ -189,7 +188,7 @@ func ExampleCommands_Navigate_second() {
 
 func ExampleCommands_ResourcesUsed() {
 	// Read metadata mock
-	content, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata.json")
 	if err != nil {
 		fmt.Print("Coult no read metadata mock file metadata.json")
 	}
@@ -271,7 +270,7 @@ func ExampleCommands_Wait() {
 
 func ExampleCommands_MetadataWorkflow() {
 	// Read metadata mock
-	content, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata.json")
 	if err != nil {
 		fmt.Print("Coult no read metadata mock file metadata.json")
 	}
@@ -305,7 +304,7 @@ func ExampleCommands_MetadataWorkflow() {
 
 func ExampleCommands_MetadataWorkflow_second() {
 	// Read metadata mock
-	content, err := ioutil.ReadFile("../../pkg/cromwell/mocks/metadata-failed.json")
+	content, err := os.ReadFile("../../pkg/cromwell/mocks/metadata-failed.json")
 	if err != nil {
 		fmt.Print("Coult no read metadata mock file metadata.json")
 	}

--- a/internal/commands/structs.go
+++ b/internal/commands/structs.go
@@ -95,7 +95,7 @@ func (mtr MetadataTableResponse) Rows() [][]string {
 }
 
 func (mtr MetadataTableResponse) collectSingleTasks() [][]string {
-	rows := [][]string{}
+	var rows [][]string
 	for call, elements := range mtr.Metadata.Calls {
 		substrings := strings.Split(call, ".")
 		for _, elem := range elements {
@@ -117,9 +117,10 @@ func (mtr MetadataTableResponse) collectSingleTasks() [][]string {
 }
 
 func (mtr MetadataTableResponse) collectScatterTasks() [][]string {
-	names := []string{}
-	duration := []time.Duration{}
-	status := []string{}
+	var names []string
+	var duration []time.Duration
+	var status []string
+
 	for call, elements := range mtr.Metadata.Calls {
 		substrings := strings.Split(call, ".")
 		for _, elem := range elements {
@@ -139,10 +140,10 @@ func (mtr MetadataTableResponse) collectScatterTasks() [][]string {
 		}
 	}
 
-	rows := [][]string{}
-	nShards, nStatusDone, nStatusFailed, totalDuration := countOccurence(names, status, duration)
+	var rows [][]string
+	nShards, nStatusDone, nStatusFailed, totalDuration := countOccurrence(names, status, duration)
 
-	for name, _ := range nShards {
+	for name := range nShards {
 		row := []string{fmt.Sprintf("%v (Scatter)", name), "-", totalDuration[name].String(), fmt.Sprintf("%v/%v Done | %v Failed", nStatusDone[name], nShards[name], nStatusFailed[name])}
 		rows = append(rows, row)
 	}
@@ -150,7 +151,7 @@ func (mtr MetadataTableResponse) collectScatterTasks() [][]string {
 	return rows
 }
 
-func countOccurence(names, status []string, duration []time.Duration) (map[string]int, map[string]int, map[string]int, map[string]time.Duration) {
+func countOccurrence(names, status []string, duration []time.Duration) (map[string]int, map[string]int, map[string]int, map[string]time.Duration) {
 	wfShards := make(map[string]int)
 	wfStatusDone := make(map[string]int)
 	wfStatusFailed := make(map[string]int)

--- a/main.go
+++ b/main.go
@@ -9,5 +9,5 @@ import (
 var Version = "development"
 
 func main() {
-	os.Exit(app.CLI(os.Args, Version))
+	os.Exit(app.CLI(Version))
 }

--- a/pkg/cromwell/client_test.go
+++ b/pkg/cromwell/client_test.go
@@ -1,10 +1,10 @@
 package cromwell
 
 import (
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -111,9 +111,9 @@ func TestClientQuery(t *testing.T) {
 
 	resp, _ := client.Query(ParamsQueryGet{})
 
-	expectedCound := 1
-	if resp.TotalResultsCount != expectedCound {
-		t.Errorf("Expected %v, got %v", expectedCound, resp.TotalResultsCount)
+	expectedCount := 1
+	if resp.TotalResultsCount != expectedCount {
+		t.Errorf("Expected %v, got %v", expectedCount, resp.TotalResultsCount)
 	}
 
 	totalWorkflows := len(resp.Results)
@@ -124,9 +124,9 @@ func TestClientQuery(t *testing.T) {
 
 func TestClientMetadata(t *testing.T) {
 	// Read metadata mock
-	content, err := ioutil.ReadFile("mocks/metadata.json")
+	content, err := os.ReadFile("mocks/metadata.json")
 	if err != nil {
-		t.Error("Coult no read metadata mock file metadata.json")
+		t.Error("Could no read metadata mock file metadata.json")
 	}
 
 	// Mock http server
@@ -147,9 +147,9 @@ func TestClientMetadata(t *testing.T) {
 		t.Errorf("Expected %v, got %v", 5, totalCalls)
 	}
 
-	subworkflowName := resp.Calls["HelloHere.ScatterSubworkflow"][0].SubWorkflowMetadata.WorkflowName
+	subWorkflowName := resp.Calls["HelloHere.ScatterSubworkflow"][0].SubWorkflowMetadata.WorkflowName
 	expected := "ScatterSubworkflow"
-	if subworkflowName != expected {
-		t.Errorf("Expected %v, got %v", expected, subworkflowName)
+	if subWorkflowName != expected {
+		t.Errorf("Expected %v, got %v", expected, subWorkflowName)
 	}
 }

--- a/pkg/output/writer.go
+++ b/pkg/output/writer.go
@@ -10,13 +10,9 @@ import (
 )
 
 var (
-	InfoColor    = "\033[1;34m%s\033[0m"
-	NoticeColor  = "\033[1;36m%s\033[0m"
-	WarningColor = "\033[1;33m%s\033[0m"
-	ErrorColor   = "\033[1;31m%s\033[0m"
-	DebugColor   = "\033[0;36m%s\033[0m"
-
-	NoColor = os.Getenv("TERM") == "dumb" ||
+	NoticeColor = "\033[1;36m%s\033[0m"
+	ErrorColor  = "\033[1;31m%s\033[0m"
+	NoColor     = os.Getenv("TERM") == "dumb" ||
 		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
 )
 


### PR DESCRIPTION
- Remove unused variables and parameters
- Update usage of ioutils.ReadFile -> os.ReadFile
- Fix typos