### PR TITLE
feat(tui): unified navigation, streaming chat, run diff, and task costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,32 @@ pumbaa dashboard     # Launch interactive TUI
 
 ### Prerequisites
 
-- Go 1.21+
+- Go 1.25+
 
 ### Build
 
 ```bash
-go build -o pumbaa ./cmd/pumbaa
+make build           # outputs dist/pumbaa
+# or: go build -o pumbaa ./cmd/cli
 
 # Run tests
-go test ./...
+make test
 ```
 
 ### Project Structure
 
 ```
-cmd/pumbaa/           # CLI entrypoint
+cmd/cli/              # CLI entrypoint
 internal/
-  ├── domain/         # Business entities and ports
-  ├── application/    # Use cases
+  ├── domain/         # Business entities
+  ├── application/    # Use cases and ports (hexagonal architecture)
   ├── infrastructure/ # External services (Cromwell, GCS, LLM)
   └── interfaces/     # CLI commands and TUI
+pkg/wdl/              # WDL parser (ANTLR)
 docs/                 # MkDocs documentation
 ```
+
+See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 
 ## Contributing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,13 +7,13 @@ Pumbaa is a CLI tool for interacting with the Cromwell workflow engine and WDL f
 ## Core Features
 
 - **Workflow Operations**: Submit, query, monitor, abort, and debug Cromwell workflows
-- **Interactive TUI Dashboard**: Real-time workflow monitoring with filtering and status tracking
-- **Debug TUI**: Visual tree navigation of workflow execution with call details and failure analysis
+- **Interactive TUI Dashboard**: Real-time workflow monitoring with filtering, status tracking, and run comparison (diff)
+- **Debug TUI**: Visual tree navigation of workflow execution with call details, failure analysis, and cost breakdown
 - **AI Chat Agent**: LLM-powered assistant for workflow analysis and troubleshooting (Gemini, Vertex AI, Ollama)
 - **WDL Bundle Creation**: Package WDL workflows with dependencies into distributable ZIP files
 - **WDL Indexing**: Fast search and discovery of WDL tasks and workflows
-- **Resource Monitoring**: Analyze resource usage from monitoring logs
-- **Telemetry**: Optional usage tracking with Sentry integration
+- **Resource Monitoring & Reports**: Analyze resource usage from monitoring logs and generate HTML reports with optimization recommendations
+- **Telemetry**: Optional anonymous usage tracking via a self-hosted Cloudflare Worker endpoint
 
 ## Project Structure
 
@@ -22,30 +22,41 @@ Pumbaa is a CLI tool for interacting with the Cromwell workflow engine and WDL f
 ├── internal/                   # Private application code
 │   ├── application/            # Use cases (Application Layer)
 │   │   ├── errors.go           # Application layer error types
+│   │   ├── ports/              # Port interfaces (Hexagonal Architecture)
 │   │   ├── bundle/             # WDL bundle creation
 │   │   └── workflow/           # Workflow use cases (flat structure)
 │   │       ├── abort.go        # Abort running workflows
-│   │       ├── debug.go        # Debug info parsing
+│   │       ├── batchlogs.go    # Fetch batch/task logs
+│   │       ├── cache_resolver.go # Resolve call-cache hit chains
+│   │       ├── compare.go      # Diff two workflow runs
+│   │       ├── inputs.go       # Workflow inputs retrieval
 │   │       ├── metadata.go     # Metadata retrieval
 │   │       ├── monitoring.go   # Resource usage analysis
+│   │       ├── outputs.go      # Workflow outputs retrieval
 │   │       ├── query.go        # Workflow querying
+│   │       ├── resource_report.go # Aggregate resource usage report
+│   │       ├── resource_visualization.go # HTML resource report rendering
 │   │       ├── submit.go       # Workflow submission
 │   │       └── testutil_test.go # Shared test mocks
 │   ├── config/                 # Configuration management
 │   ├── container/              # Dependency injection container
-│   ├── domain/                 # Domain entities and interfaces (Domain Layer)
+│   ├── domain/                 # Domain entities (Domain Layer)
 │   │   ├── bundle/             # Bundle entities and errors
-│   │   ├── ports/              # Port interfaces and errors
 │   │   ├── wdlindex/           # WDL index entities
 │   │   └── workflow/           # Workflow entities and errors
 │   ├── infrastructure/         # External services adapters (Infrastructure Layer)
 │   │   ├── agents/             # LLM agent infrastructure
 │   │   │   ├── llm/            # LLM providers (Gemini, Vertex, Ollama)
-│   │   │   └── tools/          # Reusable tools for agents (Cromwell, GCS, WDL)
+│   │   │   └── tools/          # Reusable tools for agents (Cromwell, GCS, local FS, WDL)
+│   │   ├── cloudlogging/       # Google Cloud Logging adapter (batch logs)
 │   │   ├── cromwell/           # Cromwell API client
+│   │   ├── metrics/            # Task metrics TSV reader/writer
+│   │   ├── recommendation/     # LLM-based resource recommendations
 │   │   ├── session/            # SQLite session management
 │   │   ├── storage/            # File storage (local and GCS)
-│   │   ├── telemetry/          # Telemetry service (Sentry/NoOp)
+│   │   ├── telemetry/          # Telemetry service (Cloudflare Worker / NoOp)
+│   │   ├── templates/          # Embedded HTML templates for reports
+│   │   ├── version/            # Version update checker
 │   │   └── wdl/                # WDL indexer implementation
 │   └── interfaces/             # UI adapters (Interface Layer)
 │       ├── cli/handler/        # CLI command handlers
@@ -65,15 +76,9 @@ Pumbaa is a CLI tool for interacting with the Cromwell workflow engine and WDL f
 
 ### 1. Domain Layer (`internal/domain/`)
 
-Contains business entities, value objects, and port interfaces. This layer has no dependencies on external frameworks or libraries.
+Contains business entities and value objects. This layer has no dependencies on external frameworks or libraries.
 
 **Packages:**
-
-- **`ports/`**: **Port interfaces (Hexagonal Architecture)**
-  - `WorkflowRepository` - Primary port for all workflow operations (execution, metadata, health, labels)
-  - `FileProvider` - Port for file storage access (local and cloud)
-  - `WDLRepository` - Port for WDL indexing operations
-  - `errors.go` - Port-level errors (`ErrFileNotFound`, `ErrFileTooLarge`, `FileError`)
 
 - **`workflow/`**: Core workflow entities (`Workflow`, `Call`, `Status`, `HealthStatus`)
   - `errors.go` - Domain errors (`ErrWorkflowNotFound`, `ValidationError`, `APIError`)
@@ -83,7 +88,17 @@ Contains business entities, value objects, and port interfaces. This layer has n
 
 ### 2. Application Layer (`internal/application/`)
 
-Contains use cases that orchestrate domain logic. Each use case is a single business operation with a clear input and output.
+Contains use cases that orchestrate domain logic, plus the port interfaces they depend on. Each use case is a single business operation with a clear input and output.
+
+**Ports (`ports/` — Hexagonal Architecture):**
+
+- `workflow.go` - `WorkflowRepository`, a composition of smaller focused interfaces (`WorkflowQuerier`, `WorkflowMetadataFetcher`, `WorkflowSubmitter`, `WorkflowAborter`, `HealthChecker`, `LabelManager`, ...). Consumers depend on the smallest interface that meets their needs.
+- `storage.go` - `FileProvider` (file content access), `FileSizeCache`, `StorageBackend`
+- `wdlindex.go` - `WDLRepository` for WDL indexing operations
+- `batchlogs.go` - `BatchLogsRepository` for fetching task logs from external log stores
+- `metrics.go` - `TaskMetricsReader` / `TaskMetricsWriter` for task metrics I/O
+- `recommendation.go` - `RecommendationGenerator` and `LLMDebugWriter` for resource optimization recommendations
+- `errors.go` - Port-level errors (`ErrFileNotFound`, `ErrFileTooLarge`, `ErrInvalidPath`, `ErrAccessDenied`, `FileError`)
 
 **Error Handling:**
 
@@ -97,13 +112,18 @@ Contains use cases that orchestrate domain logic. Each use case is a single busi
 - `metadata.go` - Retrieve workflow execution metadata
 - `abort.go` - Abort running workflows
 - `query.go` - Query workflows with filters (status, name, dates)
-- `debug.go` - Parse metadata and build execution trees for debugging
+- `inputs.go` / `outputs.go` - Retrieve workflow inputs and outputs
+- `compare.go` - Compare two workflow runs (metadata diff in the domain layer)
+- `batchlogs.go` - Fetch batch/task logs
+- `cache_resolver.go` - Follow call-cache hit chains to the original execution
 - `monitoring.go` - Analyze resource usage from monitoring logs (CPU, memory, disk)
+- `resource_report.go` - Aggregate resource usage across tasks into a report
+- `resource_visualization.go` - Render the resource report as an HTML page
 - `bundle/` - Create WDL bundles with dependency resolution
 
 ### 3. Infrastructure Layer (`internal/infrastructure/`)
 
-Contains implementations of external services and adapters for domain interfaces.
+Contains implementations of external services and adapters for the application ports.
 
 **Implementations:**
 
@@ -118,12 +138,21 @@ Contains implementations of external services and adapters for domain interfaces
     - `ollama/` - Local Ollama integration
     - `gemini.go` - Google Gemini API client
     - `vertex.go` - Google Vertex AI client
+    - `genai_stream.go` - Streaming support for genai-based providers
     - `factory.go` - LLM provider factory pattern
   - **`tools/`**: Reusable tool registry for agents
     - **`cromwell/`**: Query, status, metadata, logs, outputs tools
     - **`gcs/`**: Google Cloud Storage file download
+    - **`localfs/`**: Local file system access (read/write in the working dir)
     - **`wdl/`**: WDL search, list, and info tools
+    - **`factory.go`**: `builtinActions` table — single source for action registration, descriptions, and schema enum
     - **`registry.go`**: Tool registration and schema generation
+
+- **`cloudlogging/`**: Google Cloud Logging client implementing `ports.BatchLogsRepository`
+
+- **`metrics/`**: TSV-based implementations of `ports.TaskMetricsReader` / `ports.TaskMetricsWriter`
+
+- **`recommendation/`**: LLM-backed implementation of `ports.RecommendationGenerator` for resource optimization suggestions (plus a mock for tests)
 
 - **`wdl/`**: WDL indexer implementing `ports.WDLRepository`
   - File system traversal
@@ -138,9 +167,14 @@ Contains implementations of external services and adapters for domain interfaces
   - Uses Google ADK session interface
   - Persistent conversation state
 
-- **`telemetry/`**: Usage tracking and error reporting
-  - Sentry integration for production
-  - NoOp implementation for privacy/development
+- **`telemetry/`**: Anonymous usage tracking
+  - `cloudflare.go` - Sends events to a Cloudflare Worker endpoint (endpoint and key injected at build time via `-ldflags`)
+  - `noop.go` - NoOp implementation for privacy/development
+  - `service.go` - Service interface
+
+- **`templates/`**: Embedded HTML templates (`report.html`) used by the resource visualization use case
+
+- **`version/`**: Checks for newer pumbaa releases
 
 ### 4. Interface Layer (`internal/interfaces/`)
 
@@ -148,7 +182,9 @@ Contains adapters for user interaction. This layer depends on the application la
 
 **CLI Handlers:**
 
-- `submit`, `metadata`, `abort`, `query` - Standard workflow operations
+- `submit`, `metadata`, `abort`, `query`, `inputs`, `outputs` - Standard workflow operations
+- `diff` - Compare two workflow runs
+- `analyze`, `resource_report` - Resource analysis and reports
 - `bundle` - WDL packaging
 - `debug`, `dashboard` - Launch TUI applications
 - `chat` - Launch AI chat agent TUI
@@ -216,18 +252,16 @@ The container wires all dependencies together following the dependency inversion
                    ▼
 ┌──────────────────────────────────────────────────────┐
 │                 Application Layer                     │
-│           (Use Cases - Business Logic)                │
-└──────────────────┬───────────────────────────────────┘
-                   │
-                   ▼
-┌──────────────────────────────────────────────────────┐
-│                   Domain Layer                        │
-│      (Entities, Interfaces, Business Rules)           │
-└──────────────────▲───────────────────────────────────┘
-                   │
-                   │ implements interfaces
-                   │
-┌──────────────────┴───────────────────────────────────┐
+│      (Use Cases + Ports - Business Orchestration)     │
+└──────────────────┬───────────────▲───────────────────┘
+                   │               │
+                   ▼               │ implements ports
+┌──────────────────────────────┐   │
+│         Domain Layer         │   │
+│ (Entities, Business Rules)   │   │
+└──────────────────────────────┘   │
+                                   │
+┌──────────────────────────────────┴───────────────────┐
 │              Infrastructure Layer                     │
 │    (Cromwell Client, LLM Providers, Storage, etc)    │
 └──────────────────────────────────────────────────────┘
@@ -238,13 +272,13 @@ The container wires all dependencies together following the dependency inversion
 **Key Principles:**
 - Dependencies point inward (toward domain)
 - Domain has zero external dependencies
-- Infrastructure implements domain interfaces
+- Port interfaces live in `application/ports/`; infrastructure implements them
 - Interface layer depends only on application layer
 
 ## Key Design Patterns
 
 ### 1. Ports & Adapters (Hexagonal Architecture)
-Domain defines port interfaces in `domain/ports/`, implemented by adapters in `infrastructure/`. This inverts dependencies and allows business logic to remain independent of technical details.
+The application layer defines port interfaces in `application/ports/`, implemented by adapters in `infrastructure/`. This inverts dependencies and allows business logic to remain independent of technical details.
 
 ### 2. Use Case Pattern
 Each business operation is encapsulated in a use case with:
@@ -263,7 +297,7 @@ The `container.Container` manages object lifecycle and dependency wiring using c
 Different LLM providers implement a common interface, allowing runtime provider selection.
 
 ### 6. Adapter Pattern
-Infrastructure adapters translate between external APIs and domain interfaces.
+Infrastructure adapters translate between external APIs and application ports.
 
 ## Testing Strategy
 
@@ -274,27 +308,21 @@ Infrastructure adapters translate between external APIs and domain interfaces.
 
 ## Known Architecture Considerations
 
-### Current Simplifications
-
-1. **debuginfo package** contains both parsing and tree building logic
-   - **Reason**: Tree building is tightly coupled to metadata structure and not reused elsewhere
-   - **Impact**: Slightly mixed responsibilities, but isolated to one package
-
 ### Design Decisions
 
-- **Centralized Ports Package**: All port interfaces are defined in `domain/ports/` following Hexagonal Architecture. This makes it easy to see all external dependencies and maintains a clear boundary between domain and infrastructure.
+- **Centralized Ports Package**: All port interfaces are defined in `application/ports/` following Hexagonal Architecture. This makes it easy to see all external dependencies and maintains a clear boundary between application logic and infrastructure.
 
-- **Unified WorkflowRepository**: Single comprehensive interface for all workflow operations (execution, metadata, health, labels, costs). This eliminates interface redundancy and provides a complete contract for workflow management. Both CLI use cases and TUI handlers use the same port.
+- **Composed WorkflowRepository**: `WorkflowRepository` is a composition of small, focused interfaces (Interface Segregation Principle). Use cases depend on the narrowest interface they need (e.g. `WorkflowMetadataReader`), while the Cromwell client satisfies the full contract.
 
 - **FileProvider abstraction**: Single interface (`ports.FileProvider`) for file access, allowing implementations for local files, GCS, S3, or any other storage backend. Application layer depends only on the port.
 
 - **WDLRepository**: Dedicated port for WDL indexing operations, separating concerns between workflow execution (Cromwell) and workflow discovery (WDL index).
 
-- **Chat agent tools in infrastructure**: Tools are adapters to external services (Cromwell API, GCS, WDL files), implementing domain ports where appropriate.
+- **Chat agent tools in infrastructure**: Tools are adapters to external services (Cromwell API, GCS, local FS, WDL files), implementing application ports where appropriate.
 
 - **Session management**: Delegates to Google ADK interfaces for compatibility with future storage backends.
 
-- **Telemetry service**: Interface-based design allows NoOp implementation for privacy and development.
+- **Telemetry service**: Interface-based design with a Cloudflare Worker backend and a NoOp implementation for privacy and development. The endpoint and API key are injected at build time, so development builds send nothing.
 
 ## CI/CD Pipeline
 
@@ -325,23 +353,24 @@ The project uses GitHub Actions for continuous integration and releases:
 
 ### Core Libraries
 - **`urfave/cli/v2`**: CLI framework and command routing
-- **`charmbracelet/bubbletea`**: TUI framework (Elm architecture)
+- **`charmbracelet/bubbletea`** + **`bubbles`**: TUI framework (Elm architecture) and components
 - **`charmbracelet/lipgloss`**: TUI styling and layout
-- **`antlr4`**: WDL parsing (via generated parser)
+- **`charmbracelet/glamour`**: Markdown rendering in the chat TUI
+- **`antlr4-go/antlr/v4`**: WDL parsing (via generated parser)
 
 ### Cloud & AI
-- **`google.golang.org/genai`**: Gemini API client
-- **`cloud.google.com/go/vertexai`**: Vertex AI client
+- **`google.golang.org/genai`**: Gemini and Vertex AI clients (single SDK for both)
 - **`cloud.google.com/go/storage`**: GCS file access
+- **`cloud.google.com/go/logging`**: Google Cloud Logging (batch logs)
 - **Ollama**: Local LLM via HTTP API
 
 ### Infrastructure
-- **`getsentry/sentry-go`**: Error tracking and telemetry
 - **`google.golang.org/adk`**: Agent Development Kit (sessions, tools)
-- **`mattn/go-sqlite3`**: Session storage
+- **`modernc.org/sqlite`**: Session storage (pure-Go SQLite driver, no CGO)
+- **Telemetry**: In-house HTTP client posting to a Cloudflare Worker (no third-party tracking SDK)
 
 ---
 
-**Last Updated**: 2025-12-26
-**Document Version**: 2.1
+**Last Updated**: 2026-07-07
+**Document Version**: 2.2
 **Project Version**: See [releases](https://github.com/lmtani/pumbaa/releases)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Pumbaa! :heart:
 
 ### Prerequisites
 
-- Go 1.21+
+- Go 1.25+
 - Make
 
 ### Build

--- a/docs/features/abort.md
+++ b/docs/features/abort.md
@@ -23,6 +23,8 @@ Stop running workflows.
 pumbaa workflow abort <workflow-id>
 ```
 
+Aliases: `pumbaa wf a`, `pumbaa wf kill`
+
 ## :material-lightbulb: Example
 
 ```bash

--- a/docs/features/bundle.md
+++ b/docs/features/bundle.md
@@ -21,8 +21,10 @@ Package WDL workflows with dependencies into ZIP files.
 ## :material-rocket-launch: Quick Start
 
 ```bash
-pumbaa bundle create --workflow FILE --output FILE
+pumbaa bundle --workflow FILE --output FILE
 ```
+
+Aliases: `pumbaa b`, `pumbaa pack`
 
 ## :material-flag: Flags
 
@@ -59,7 +61,7 @@ tasks/
 === "Create Bundle"
 
     ```bash
-    pumbaa bundle create \
+    pumbaa bundle \
       --workflow pipeline.wdl \
       --output bundle.zip
     ```

--- a/docs/features/chat.md
+++ b/docs/features/chat.md
@@ -93,21 +93,36 @@ Choose your preferred AI backend:
     
     Fetch files from Google Cloud Storage
 
+-   :material-file-edit: **Write Files**
+    
+    Save scripts or notes to the working directory
+
+-   :material-book-search: **WDL Knowledge Base**
+    
+    List, search, and inspect your indexed WDL workflows (`PUMBAA_WDL_DIR`)
+
 </div>
+
+!!! info "Streaming"
+    Responses stream in real time as the model generates them. Press ++esc++ during generation to cancel it.
 
 ## :material-keyboard: Controls
 
 | Key | Action |
 |:---:|--------|
-| ++ctrl+d++ | Send message |
+| ++enter++ | Send message |
+| ++ctrl+j++ | Insert line break |
 | ++up++ / ++down++ | Scroll messages (input mode) |
 | ++tab++ | Toggle navigation mode |
-| ++y++ | Copy selected message |
-| ++esc++ | Exit chat |
+| ++y++ | Copy selected message (navigation mode) |
+| ++g++ / ++shift+g++ | First / last message (navigation mode) |
+| ++ctrl+s++ | Browse and switch sessions |
+| ++ctrl+r++ | Resume previous session for the same task |
+| ++esc++ | Cancel generation · leave input · exit chat |
 
 ## :material-floppy: Session Management
 
-Conversations are persisted in SQLite for context retention.
+Conversations are persisted in SQLite (`~/.pumbaa/sessions.db`) for context retention.
 
 ```bash
 # List existing sessions
@@ -116,6 +131,12 @@ pumbaa chat --list
 # Resume a session
 pumbaa chat --session <SESSION_ID>
 ```
+
+Inside the TUI:
+
+- ++ctrl+s++ opens a session browser to switch conversations
+- ++ctrl+r++ resumes the most recent session for the current task
+- Opening the chat from the debug view for the same task automatically resumes that task's conversation
 
 ## :material-cog: Configuration
 
@@ -126,7 +147,7 @@ pumbaa chat --session <SESSION_ID>
     ```bash
     export PUMBAA_LLM_PROVIDER=gemini
     export GEMINI_API_KEY=<your-api-key>
-    export GEMINI_MODEL=gemini-2.0-flash  # optional
+    export GEMINI_MODEL=gemini-2.5-flash  # optional
     ```
 
 === ":material-server: Ollama"
@@ -143,7 +164,7 @@ pumbaa chat --session <SESSION_ID>
     export PUMBAA_LLM_PROVIDER=vertex
     export VERTEX_PROJECT=<project-id>
     export VERTEX_LOCATION=us-central1
-    export VERTEX_MODEL=gemini-2.0-flash
+    export VERTEX_MODEL=gemini-2.5-flash
     ```
 
 ### Session Storage

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -26,14 +26,19 @@ pumbaa dashboard
 |:---:|--------|
 | ++up++ / ++down++ | Navigate |
 | ++enter++ | Open debug view |
-| ++a++ | Abort workflow |
+| ++a++ | Abort workflow (Running/Submitted only) |
 | ++s++ | Filter by status |
 | ++slash++ | Filter by name |
 | ++l++ | Filter by label |
-| ++r++ | Refresh |
+| ++u++ | Go to workflow by UUID |
 | ++ctrl+x++ | Clear filters |
 | ++shift+l++ | Manage labels |
-| ++q++ | Quit |
+| ++c++ | Compare runs (mark base, then target) |
+| ++e++ | Error details |
+| ++r++ | Refresh |
+| ++w++ | Toggle auto-refresh |
+| ++question++ | Help overlay |
+| ++esc++ | Back / quit · ++ctrl+c++ quits immediately |
 
 
 ## :material-star: Features
@@ -56,7 +61,27 @@ pumbaa dashboard
     
     Press ++a++ to abort with confirmation
 
+-   :material-file-compare: **Compare Runs**
+    
+    Press ++c++ on two workflows to diff them
+
+-   :material-refresh-auto: **Auto-refresh**
+    
+    Press ++w++ to keep the list updating
+
 </div>
+
+## :material-file-compare: Comparing Two Runs
+
+To understand why two executions of the same pipeline behaved differently:
+
+1. Press ++c++ on the first workflow to mark it as the **base**
+2. Press ++c++ on a second workflow to open the **diff modal**
+
+The diff shows differences in **inputs**, **options**, and **per-task metrics** (duration, resources), resolving call-cache hits to their original executions so cached tasks show real numbers.
+
+!!! tip "CLI equivalent"
+    The same comparison is available non-interactively: `pumbaa workflow diff <id-a> <id-b>` (see [Diff](diff.md)).
 
 
 ## :material-table: Workflow Columns

--- a/docs/features/debug.md
+++ b/docs/features/debug.md
@@ -34,8 +34,10 @@ Inspect workflow execution tree and call-level details.
 === "CLI"
 
     ```bash
-    pumbaa workflow debug <workflow-id>
+    pumbaa workflow debug --id <workflow-id>
     ```
+
+    Other options: `--file metadata.json` to debug from a saved metadata file (offline), and `--expand-subworkflows` to fetch subworkflow metadata upfront.
 
 ## :material-keyboard: Navigation
 
@@ -47,9 +49,18 @@ Inspect workflow execution tree and call-level details.
 | ++tab++ | Switch panel focus |
 | ++shift+e++ | Expand all nodes |
 | ++shift+c++ | Collapse all nodes |
-| ++y++ | Copy to clipboard |
+| ++slash++ | Search tree · ++n++ / ++shift+n++ next/prev match |
+| ++f++ | Expand failed/preempted paths |
+| ++"]"++ / ++"["++ | Jump to next / previous failure |
+| ++shift+f++ | Failure summary (grouped by error) |
+| ++e++ | Error details for selected node |
+| ++d++ | Node details panel |
+| ++"$"++ | Cost breakdown by task |
+| ++w++ | Watch mode (auto-refresh) |
+| ++y++ | Copy menu (context-sensitive) |
+| ++"<"++ / ++">"++ | Resize tree/details split |
 | ++a++ | Chat with AI |
-| ++q++ | Back / Quit |
+| ++esc++ | Close modal / back · ++ctrl+c++ quits |
 
 ## :material-lightning-bolt: Quick Actions
 
@@ -120,6 +131,28 @@ The timeline shows:
 
 !!! tip "Subworkflow Timelines"
     Navigate to a subworkflow node and press ++4++ to see its specific timeline, separate from the parent workflow.
+
+## :material-currency-usd: Cost Breakdown
+
+Press ++"$"++ to open the per-task cost breakdown modal.
+
+- Tasks are listed with their **estimated cost**, sorted by the most expensive first
+- Costs are billed on **VM lifetime** (provisioning to teardown), not just task wall-clock time
+- **Subworkflow costs are included by default** — the modal fetches expanded metadata as needed
+
+!!! tip "Where is my money going?"
+    Combine the cost modal with the timeline (++4++) and resource efficiency (++5++) views: the most expensive tasks are usually the best candidates for right-sizing.
+
+## :material-alert-circle: Investigating Failures
+
+For workflows with failed tasks:
+
+1. Press ++f++ to expand only the failed/preempted paths of the tree
+2. Jump between failures with ++"]"++ / ++"["++
+3. Press ++shift+f++ for a **failure summary** modal that groups failures by error message
+4. Press ++e++ on a node to see its full error details
+
+For workflows still running, press ++w++ to enable **watch mode** — the tree refreshes automatically while preserving your expand/collapse state.
 
 ## :material-chart-areaspline: Resource Efficiency
 

--- a/docs/features/diff.md
+++ b/docs/features/diff.md
@@ -1,0 +1,90 @@
+# Diff Two Runs
+
+Compare two workflow runs: inputs, options, WDL source, and per-task changes.
+
+<div class="grid cards" markdown>
+
+-   :material-file-compare: **Full Comparison**
+
+    Inputs, options, source, and task-level differences
+
+-   :material-cached: **Cache-aware**
+
+    Recovers real metrics of call-cached tasks from their source runs
+
+-   :material-code-json: **JSON Output**
+
+    Machine-readable diff for scripting
+
+</div>
+
+## :material-rocket-launch: Quick Start
+
+```bash
+pumbaa workflow diff <workflow-id-a> <workflow-id-b>
+```
+
+Alias: `pumbaa wf compare`
+
+## :material-flag: Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output the diff as JSON |
+| `--no-cache-resolve` | Do not fetch cache sources to recover real metrics of cache-hit tasks |
+
+## :material-file-document: Output
+
+The diff is organized in four sections:
+
+| Section | What it shows |
+|---------|---------------|
+| **Inputs** | Added (`+`), removed (`-`), and changed (`~`) input keys |
+| **Options** | Same, for workflow options |
+| **Source** | Whether the submitted WDL source changed (with line counts) |
+| **Tasks** | Tasks only in one run, plus status, docker image, shard count, attempts, and duration changes |
+
+Duration changes come with a verdict (e.g. `2.3× slower`), making regressions easy to spot.
+
+!!! info "Call caching"
+    When a task was a **call-cache hit**, its wall-clock time says nothing about real performance. By default, Pumbaa follows the cache back to the source run and compares the **original** metrics. Use `--no-cache-resolve` to skip this (faster, fewer API calls).
+
+## :material-lightbulb: Examples
+
+=== "Human-readable"
+
+    ```bash
+    pumbaa workflow diff abc-123 def-456
+    ```
+
+=== "JSON for scripting"
+
+    ```bash
+    pumbaa workflow diff abc-123 def-456 --json | jq '.Tasks'
+    ```
+
+!!! tip "From the dashboard"
+    The same comparison is available interactively: press ++c++ on two workflows in the [Dashboard](dashboard.md).
+
+## :material-wrench: Use Cases
+
+<div class="grid cards" markdown>
+
+-   :material-speedometer: **Performance Regressions**
+
+    Why did this run take twice as long?
+
+-   :material-bug: **Failure Triage**
+
+    What changed between the run that worked and the one that failed?
+
+-   :material-docker: **Image Updates**
+
+    Confirm which tasks picked up a new docker image
+
+</div>
+
+## :material-book-open-variant: See Also
+
+- [:material-view-dashboard: Dashboard](dashboard.md) — Interactive diff with ++c++
+- [:material-file-document: Metadata](metadata.md) — Single-run details

--- a/docs/features/inputs-outputs.md
+++ b/docs/features/inputs-outputs.md
@@ -1,0 +1,57 @@
+# Inputs & Outputs
+
+Retrieve the submitted inputs or generated outputs of a workflow.
+
+## :material-rocket-launch: Quick Start
+
+=== "Inputs"
+
+    ```bash
+    pumbaa workflow inputs <workflow-id>
+    ```
+
+    Aliases: `pumbaa wf i`, `pumbaa wf in`
+
+=== "Outputs"
+
+    ```bash
+    pumbaa workflow outputs <workflow-id>
+    ```
+
+    Aliases: `pumbaa wf o`, `pumbaa wf out`
+
+## :material-flag: Flags
+
+| Flag | Alias | Description |
+|------|:-----:|-------------|
+| `--json` | `-j` | Output as JSON instead of a table |
+
+## :material-lightbulb: Examples
+
+=== "Inspect inputs"
+
+    ```bash
+    pumbaa workflow inputs abc-123
+    ```
+
+    Human-readable key-value listing (the workflow name prefix is stripped for readability).
+
+=== "Pipe outputs to a script"
+
+    ```bash
+    pumbaa workflow outputs abc-123 --json | jq -r '.["pipeline.final_vcf"]'
+    ```
+
+=== "Reuse inputs for a new submission"
+
+    ```bash
+    pumbaa workflow inputs abc-123 --json > inputs.json
+    # edit inputs.json, then:
+    pumbaa workflow submit --workflow pipeline.wdl --inputs inputs.json
+    ```
+
+## :material-book-open-variant: See Also
+
+- [:material-upload: Submit](submit.md) — Resubmit with modified inputs
+- [:material-file-document: Metadata](metadata.md) — Status, timing, and calls
+- [:material-file-compare: Diff](diff.md) — Compare inputs between two runs

--- a/docs/features/metadata.md
+++ b/docs/features/metadata.md
@@ -21,28 +21,16 @@ Get detailed workflow metadata.
 ## :material-rocket-launch: Quick Start
 
 ```bash
-pumbaa workflow metadata <workflow-id> [FLAGS]
+pumbaa workflow metadata <workflow-id>
 ```
 
-## :material-flag: Flags
+Aliases: `pumbaa wf m`, `pumbaa wf meta`
 
-| Flag | Alias | Description |
-|------|:-----:|-------------|
-| `--verbose` | `-v` | Show detailed call information |
+## :material-lightbulb: Example
 
-## :material-lightbulb: Examples
-
-=== "Basic"
-
-    ```bash
-    pumbaa workflow metadata abc12345
-    ```
-
-=== "Verbose"
-
-    ```bash
-    pumbaa workflow metadata abc12345 --verbose
-    ```
+```bash
+pumbaa workflow metadata abc12345-6789-0def-ghij-klmnopqrstuv
+```
 
 ## :material-file-document: Output
 
@@ -51,11 +39,13 @@ pumbaa workflow metadata <workflow-id> [FLAGS]
 | Workflow ID | Full UUID |
 | Name | WDL workflow name |
 | Status | Current state |
-| Timing | Start/end timestamps |
-| Inputs | Submitted inputs |
-| Outputs | Generated outputs |
+| Timing | Start/end timestamps and duration |
 | Labels | User labels |
-| Calls | Task execution details (with `-v`) |
+| Calls | Per-task status, timing, and attempts |
+| Failures | Error messages for failed workflows |
+
+!!! tip "Inputs and outputs"
+    Submitted inputs and generated outputs have their own commands: see [Inputs & Outputs](inputs-outputs.md).
 
 ## :material-wrench: Use Cases
 

--- a/docs/features/query.md
+++ b/docs/features/query.md
@@ -20,6 +20,8 @@ List and filter workflows via CLI.
 pumbaa workflow query [FLAGS]
 ```
 
+Aliases: `pumbaa wf q`, `pumbaa wf list`
+
 ## :material-flag: Flags
 
 | Flag | Alias | Description |
@@ -73,7 +75,7 @@ pumbaa workflow query [FLAGS]
 
 Displays table with:
 
-- **ID** — First 8 chars
+- **ID** — Workflow UUID
 - **Name** — Workflow name
 - **Status** — Color-coded
 - **Submitted** — Timestamp

--- a/docs/features/submit.md
+++ b/docs/features/submit.md
@@ -24,6 +24,8 @@ Submit WDL workflows to Cromwell.
 pumbaa workflow submit --workflow FILE [OPTIONS]
 ```
 
+Alias: `pumbaa wf s`
+
 ## :material-flag: Flags
 
 | Flag | Alias | Required | Description |
@@ -98,7 +100,7 @@ Configure workflow execution:
 For workflows with imports, create ZIP with imported files:
 
 ```bash
-pumbaa bundle create --workflow workflow.wdl --output deps.zip
+pumbaa bundle --workflow workflow.wdl --output deps.zip
 ```
 
 Then submit:
@@ -124,19 +126,18 @@ pumbaa workflow submit \
 
 ## :material-check-circle: Response
 
-```json
-{
-  "id": "abc12345-6789-0def-ghij-klmnopqrstuv",
-  "status": "Submitted"
-}
+```text
+✓ Workflow submitted successfully!
+  Workflow ID: abc12345-6789-0def-ghij-klmnopqrstuv
+  Status: Submitted
 ```
 
 Use the ID to monitor:
 
 ```bash
 pumbaa dashboard                    # Interactive
-pumbaa workflow debug <id>          # Debug view  
-pumbaa workflow query --id <id>     # CLI query
+pumbaa workflow debug --id <id>     # Debug view
+pumbaa workflow metadata <id>       # CLI metadata
 ```
 
 ## :material-book-open-variant: See Also

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -52,11 +52,36 @@ pumbaa config path
 | `ollama_host` | Ollama server URL | `http://localhost:11434` |
 | `ollama_model` | Ollama model name | `llama3.2:3b` |
 | `gemini_api_key` | Gemini API key | `AIza...` |
-| `gemini_model` | Gemini model | `gemini-2.0-flash` |
+| `gemini_model` | Gemini model | `gemini-2.5-flash` |
 | `vertex_project` | GCP project ID | `my-project` |
 | `vertex_location` | Vertex AI region | `us-central1` |
-| `vertex_model` | Vertex AI model | `gemini-2.0-flash` |
+| `vertex_model` | Vertex AI model | `gemini-2.5-flash` |
 | `wdl_directory` | WDL files for context | `/path/to/workflows` |
+
+---
+
+## :material-application-variable: Environment Variables
+
+Every setting can also be provided via environment variable. Env vars override the config file.
+
+| Variable | Equivalent config key | Default |
+|----------|----------------------|---------|
+| `CROMWELL_HOST` | `cromwell_host` | `http://localhost:8000` |
+| `PUMBAA_LLM_PROVIDER` | `llm_provider` | `ollama` |
+| `OLLAMA_HOST` | `ollama_host` | `http://localhost:11434` |
+| `OLLAMA_MODEL` | `ollama_model` | `llama3.2:3b` |
+| `GEMINI_API_KEY` | `gemini_api_key` | — |
+| `GEMINI_MODEL` | `gemini_model` | `gemini-2.5-flash` |
+| `VERTEX_PROJECT` | `vertex_project` | — |
+| `VERTEX_LOCATION` | `vertex_location` | `us-central1` |
+| `VERTEX_MODEL` | `vertex_model` | `gemini-2.5-flash` |
+| `PUMBAA_WDL_DIR` | `wdl_directory` | — |
+| `PUMBAA_WDL_INDEX` | — (WDL index cache path) | `~/.pumbaa/wdl_index.json` |
+| `PUMBAA_SESSION_DB` | — (chat sessions database) | `~/.pumbaa/sessions.db` |
+| `PUMBAA_TELEMETRY_ENABLED` | `telemetry_enabled` | `true` |
+
+!!! warning "Prefix inconsistency"
+    Provider variables follow their ecosystem's conventions and do **not** use the `PUMBAA_` prefix: it is `OLLAMA_HOST`, `GEMINI_API_KEY`, `VERTEX_PROJECT` — not `PUMBAA_OLLAMA_HOST`.
 
 ---
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -69,7 +69,9 @@ pumbaa dashboard
 | ++a++ | Abort workflow |
 | ++shift+l++ | Manage labels |
 | ++r++ | Refresh |
-| ++q++ | Quit |
+| ++w++ | Toggle auto-refresh |
+| ++question++ | Help (all shortcuts) |
+| ++esc++ | Back / quit |
 
 ---
 
@@ -126,7 +128,19 @@ pumbaa workflow submit \
 -   :material-package: **Bundle WDL**
     
     ```bash
-    pumbaa bundle --workflow main.wdl
+    pumbaa bundle --workflow main.wdl --output bundle.zip
+    ```
+
+-   :material-file-compare: **Compare Two Runs**
+    
+    ```bash
+    pumbaa workflow diff <id-a> <id-b>
+    ```
+
+-   :material-robot: **Ask the AI Agent**
+    
+    ```bash
+    pumbaa chat
     ```
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Pumbaa is a command-line tool that simplifies interaction with [Cromwell](https:
     Package your workflow with all dependencies into a single distributable file.
     
     ```bash
-    pumbaa bundle --workflow main.wdl
+    pumbaa bundle --workflow main.wdl --output bundle.zip
     ```
 
 </div>

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -16,9 +16,10 @@ internal/
 │   ├── monitoring.go
 │   └── monitoring_test.go
 ├── application/workflow/
-│   └── debuginfo/
-│       ├── usecase.go
-│       └── usecase_test.go
+│   ├── metadata.go
+│   ├── metadata_test.go
+│   ├── query.go
+│   └── query_test.go
 └── infrastructure/cromwell/
     ├── mapper.go
     └── mapper_test.go
@@ -75,15 +76,18 @@ func TestCalculatePreemptionSummary(t *testing.T) {
 
 ### Test Data
 
-Place test fixtures in `test_data/`:
+Shared fixtures live in the top-level `test_data/` directory:
 
 ```
 test_data/
 ├── metadata.json           # Cromwell workflow metadata
-├── metadata_scattered.json # Scattered workflow example
-├── monitoring.tsv          # Resource monitoring output
-└── monitoring_empty.tsv    # Edge case: empty log
+└── wdl/                    # Sample WDL files for indexer/parser tests
+    ├── hello.wdl
+    ├── subworkflow/
+    └── tasks/
 ```
+
+Fixtures used by a single package are kept next to that package (package-local test data), not in `test_data/`.
 
 Load test data with relative paths:
 
@@ -164,7 +168,7 @@ go tool cover -html=coverage.out
 For infrastructure dependencies, create interfaces and mock implementations:
 
 ```go
-// In domain/ports/workflow.go
+// In internal/application/ports/workflow.go
 type WorkflowRepository interface {
     GetMetadata(ctx context.Context, id string) (*workflow.Workflow, error)
 }
@@ -179,6 +183,21 @@ func (m *mockRepository) GetMetadata(ctx context.Context, id string) (*workflow.
     return m.metadata, m.err
 }
 ```
+
+## Agent Tools E2E Test
+
+`internal/infrastructure/agents/tools/e2e_test.go` contains `TestToolsE2E`, which exercises every built-in agent action against a real Cromwell server (and, optionally, a real WDL directory). It is the "are the tools actually functional" check.
+
+The test is opt-in: it is skipped unless `PUMBAA_TOOLS_E2E=1` is set, because it needs live infrastructure.
+
+```bash
+PUMBAA_TOOLS_E2E=1 CROMWELL_HOST=http://localhost:8000 \
+PUMBAA_WDL_DIR=/path/to/workflows \
+go test ./internal/infrastructure/agents/tools/ -run TestToolsE2E -v
+```
+
+!!! note
+    `CROMWELL_HOST` defaults to `http://localhost:8000` when unset. `PUMBAA_WDL_DIR` is optional; without it, the WDL tools are not exercised.
 
 ## Edge Cases to Test
 

--- a/internal/domain/workflow/cost.go
+++ b/internal/domain/workflow/cost.go
@@ -1,0 +1,121 @@
+// cost.go contains per-task cost breakdown logic for a workflow. It reuses
+// the same attempt-cost estimate as the preemption analysis, but aggregates
+// every task (preemptible or not) so users can see where the money goes.
+package workflow
+
+import "sort"
+
+// TaskCost is a Value Object with the aggregated cost of one task (summed
+// across its shards and attempts).
+type TaskCost struct {
+	Name         string  // Short task name (without workflow prefix)
+	TotalCost    float64 // Cost of all shards/attempts
+	VMHours      float64 // Sum of compute time across shards/attempts, in hours
+	ShardCount   int     // Number of shards
+	AttemptCount int     // Total attempts across shards
+	Preemptible  bool    // True if the task ran on preemptible VMs
+	FromActual   bool    // True when cost came from real vmCostPerHour (not an estimate)
+	Percent      float64 // Share of the workflow's TotalCost
+}
+
+// CostBreakdown is a Value Object with per-task costs for a workflow,
+// sorted by cost descending.
+type CostBreakdown struct {
+	Tasks      []TaskCost
+	TotalCost  float64 // Sum of Tasks' cost (reconstructed from loaded metadata)
+	FromActual bool    // True when every task's cost came from real vmCostPerHour
+	// SubworkflowsPending is the number of subworkflow calls whose metadata
+	// was not loaded, so their tasks are absent from this breakdown.
+	SubworkflowsPending int
+}
+
+// CalculateCostBreakdown aggregates the cost of every task in the workflow,
+// recursing into any loaded subworkflow metadata. Subworkflow calls whose
+// metadata has not been fetched are counted in SubworkflowsPending so callers
+// can tell the breakdown is partial.
+func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
+	type agg struct {
+		cost       float64
+		vmHours    float64
+		shards     map[int]bool
+		attempts   int
+		preempt    bool
+		fromActual bool
+		allActual  bool
+	}
+	aggregations := make(map[string]*agg)
+	var order []string
+	pending := 0
+
+	var walk func(calls map[string][]Call)
+	walk = func(calls map[string][]Call) {
+		for callName, callList := range calls {
+			short := preemptionShortTaskName(callName)
+			for _, call := range callList {
+				if call.SubWorkflowMetadata != nil {
+					walk(call.SubWorkflowMetadata.Calls)
+					continue
+				}
+				if call.SubWorkflowID != "" {
+					// A subworkflow call whose metadata was not loaded.
+					pending++
+					continue
+				}
+
+				a := aggregations[short]
+				if a == nil {
+					a = &agg{shards: make(map[int]bool), allActual: true}
+					aggregations[short] = a
+					order = append(order, short)
+				}
+				cost := calculateAttemptCost(call)
+				a.cost += cost
+				a.attempts++
+				a.shards[call.ShardIndex] = true
+				if IsPreemptible(call.Preemptible) {
+					a.preempt = true
+				}
+				if call.VMCostPerHour > 0 && billableHours(call) > 0 {
+					a.vmHours += billableHours(call)
+					a.fromActual = true
+				} else {
+					a.allActual = false
+				}
+			}
+		}
+	}
+	walk(w.Calls)
+
+	breakdown := &CostBreakdown{
+		FromActual:          true,
+		SubworkflowsPending: pending,
+	}
+	for _, name := range order {
+		a := aggregations[name]
+		breakdown.TotalCost += a.cost
+		if !a.allActual {
+			breakdown.FromActual = false
+		}
+		breakdown.Tasks = append(breakdown.Tasks, TaskCost{
+			Name:         name,
+			TotalCost:    a.cost,
+			VMHours:      a.vmHours,
+			ShardCount:   len(a.shards),
+			AttemptCount: a.attempts,
+			Preemptible:  a.preempt,
+			FromActual:   a.fromActual && a.allActual,
+		})
+	}
+
+	if breakdown.TotalCost > 0 {
+		for i := range breakdown.Tasks {
+			breakdown.Tasks[i].Percent = breakdown.Tasks[i].TotalCost / breakdown.TotalCost * 100
+		}
+	}
+
+	sort.Slice(breakdown.Tasks, func(i, j int) bool {
+		return breakdown.Tasks[i].TotalCost > breakdown.Tasks[j].TotalCost
+	})
+
+	return breakdown
+}

--- a/internal/domain/workflow/cost_test.go
+++ b/internal/domain/workflow/cost_test.go
@@ -1,0 +1,87 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+)
+
+func hoursApart(start string, h float64) (time.Time, time.Time) {
+	s, _ := time.Parse(time.RFC3339, start)
+	return s, s.Add(time.Duration(h * float64(time.Hour)))
+}
+
+func TestCalculateCostBreakdownAggregatesAndSorts(t *testing.T) {
+	s1, e1 := hoursApart("2026-07-06T06:00:00Z", 10) // expensive, non-preemptible
+	s2, e2 := hoursApart("2026-07-06T06:00:00Z", 2)  // cheaper, preemptible
+	s3, e3 := hoursApart("2026-07-06T06:00:00Z", 2)  // second shard of the cheap task
+
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.Merge": {
+				{Name: "WF.Merge", ShardIndex: -1, Attempt: 1, Start: s1, End: e1, VMCostPerHour: 0.20, Preemptible: "false"},
+			},
+			"WF.Collect": {
+				{Name: "WF.Collect", ShardIndex: 0, Attempt: 1, Start: s2, End: e2, VMCostPerHour: 0.05, Preemptible: "true"},
+				{Name: "WF.Collect", ShardIndex: 1, Attempt: 1, Start: s3, End: e3, VMCostPerHour: 0.05, Preemptible: "true"},
+			},
+		},
+	}
+
+	b := wf.CalculateCostBreakdown()
+
+	if len(b.Tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(b.Tasks))
+	}
+	// Merge = 10h * 0.20 = 2.00; Collect = 2*(2h*0.05) = 0.20
+	if b.Tasks[0].Name != "Merge" {
+		t.Errorf("expected Merge first (most expensive), got %s", b.Tasks[0].Name)
+	}
+	if got := b.Tasks[0].TotalCost; got < 1.99 || got > 2.01 {
+		t.Errorf("Merge cost = %.3f, want ~2.00", got)
+	}
+	if b.Tasks[0].Preemptible {
+		t.Errorf("Merge should be non-preemptible")
+	}
+	if b.Tasks[1].Name != "Collect" || b.Tasks[1].ShardCount != 2 {
+		t.Errorf("Collect should have 2 shards, got %s/%d", b.Tasks[1].Name, b.Tasks[1].ShardCount)
+	}
+	if !b.Tasks[1].Preemptible {
+		t.Errorf("Collect should be preemptible")
+	}
+	if total := b.TotalCost; total < 2.19 || total > 2.21 {
+		t.Errorf("total = %.3f, want ~2.20", total)
+	}
+	if p := b.Tasks[0].Percent; p < 90 || p > 91 {
+		t.Errorf("Merge percent = %.1f, want ~90.9", p)
+	}
+	if !b.FromActual {
+		t.Errorf("expected FromActual true when all costs use vmCostPerHour")
+	}
+}
+
+func TestCalculateCostBreakdownRecursesLoadedSubworkflowAndCountsPending(t *testing.T) {
+	s, e := hoursApart("2026-07-06T06:00:00Z", 1)
+
+	loaded := &Workflow{
+		Calls: map[string][]Call{
+			"Sub.Inner": {{Name: "Sub.Inner", ShardIndex: -1, Attempt: 1, Start: s, End: e, VMCostPerHour: 0.10, Preemptible: "false"}},
+		},
+	}
+
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.LoadedSub":   {{Name: "WF.LoadedSub", SubWorkflowID: "sub-1", SubWorkflowMetadata: loaded}},
+			"WF.PendingSub":  {{Name: "WF.PendingSub", SubWorkflowID: "sub-2"}}, // not loaded
+			"WF.PendingSub2": {{Name: "WF.PendingSub2", SubWorkflowID: "sub-3"}},
+		},
+	}
+
+	b := wf.CalculateCostBreakdown()
+
+	if len(b.Tasks) != 1 || b.Tasks[0].Name != "Inner" {
+		t.Fatalf("expected only the loaded subworkflow's Inner task, got %+v", b.Tasks)
+	}
+	if b.SubworkflowsPending != 2 {
+		t.Errorf("expected 2 pending subworkflows, got %d", b.SubworkflowsPending)
+	}
+}

--- a/internal/domain/workflow/preemption.go
+++ b/internal/domain/workflow/preemption.go
@@ -256,12 +256,28 @@ func analyzeTaskShard(attempts []Call) PreemptionTaskStats {
 	return stats
 }
 
+// billableHours returns the VM lifetime in hours — the basis Cromwell uses to
+// bill. It prefers vmStartTime/vmEndTime (actual VM uptime) and falls back to
+// the task's Start/End when VM timestamps are absent. Using the task wall-clock
+// overestimates cost, since it includes queueing and localization outside the
+// billed VM window.
+func billableHours(call Call) float64 {
+	if !call.VMStartTime.IsZero() && !call.VMEndTime.IsZero() {
+		return call.VMEndTime.Sub(call.VMStartTime).Hours()
+	}
+	if !call.Start.IsZero() && !call.End.IsZero() {
+		return call.End.Sub(call.Start).Hours()
+	}
+	return 0
+}
+
 // calculateAttemptCost calculates the estimated cost of a single attempt.
 func calculateAttemptCost(call Call) float64 {
-	// If we have actual VM cost per hour, use it
-	if call.VMCostPerHour > 0 && !call.Start.IsZero() && !call.End.IsZero() {
-		durationHours := call.End.Sub(call.Start).Hours()
-		return call.VMCostPerHour * durationHours
+	// If we have actual VM cost per hour, use it against the billed VM lifetime
+	if call.VMCostPerHour > 0 {
+		if hours := billableHours(call); hours > 0 {
+			return call.VMCostPerHour * hours
+		}
 	}
 
 	// Otherwise, estimate using resource-hours
@@ -274,10 +290,7 @@ func calculateAttemptCost(call Call) float64 {
 		mem = 1
 	}
 
-	var durationHours float64
-	if !call.Start.IsZero() && !call.End.IsZero() {
-		durationHours = call.End.Sub(call.Start).Hours()
-	}
+	durationHours := billableHours(call)
 	if durationHours <= 0 {
 		durationHours = 0.01 // Minimum 36 seconds
 	}

--- a/internal/infrastructure/agents/llm/gemini.go
+++ b/internal/infrastructure/agents/llm/gemini.go
@@ -51,41 +51,16 @@ func (m *GeminiModel) Name() string {
 	return fmt.Sprintf("gemini/%s", m.modelName)
 }
 
-// GenerateContent implements model.LLM.GenerateContent.
+// GenerateContent implements model.LLM.GenerateContent. Streaming yields
+// Partial responses per chunk followed by one aggregated final response.
 func (m *GeminiModel) GenerateContent(
 	ctx context.Context,
 	req *model.LLMRequest,
 	stream bool,
 ) iter.Seq2[*model.LLMResponse, error] {
-	return func(yield func(*model.LLMResponse, error) bool) {
-		// Build the genai request
-		genaiReq := &genai.GenerateContentConfig{}
-
-		if req.Config != nil {
-			genaiReq = req.Config
-		}
-
-		// Use the genai client to generate content
-		resp, err := m.client.Models.GenerateContent(ctx, m.modelName, req.Contents, genaiReq)
-		if err != nil {
-			_ = yield(nil, fmt.Errorf("Gemini API generation failed: %w", err))
-			return
-		}
-
-		// Convert response
-		if len(resp.Candidates) == 0 {
-			_ = yield(nil, fmt.Errorf("no candidates in response"))
-			return
-		}
-
-		candidate := resp.Candidates[0]
-		adkResp := &model.LLMResponse{
-			Content:       candidate.Content,
-			UsageMetadata: resp.UsageMetadata,
-		}
-
-		_ = yield(adkResp, nil)
-	}
+	return generateGenaiContent(ctx, m.client, m.modelName, req, stream, func(err error) error {
+		return fmt.Errorf("Gemini API generation failed: %w", err)
+	})
 }
 
 // Close closes the client connection.

--- a/internal/infrastructure/agents/llm/genai_stream.go
+++ b/internal/infrastructure/agents/llm/genai_stream.go
@@ -1,0 +1,108 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strings"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+// generateGenaiContent adapts a genai client call to the ADK iterator
+// contract, shared by the Gemini and Vertex models.
+//
+// When stream is false it yields the single complete response. When stream
+// is true it yields each text chunk as a Partial response and finishes with
+// one aggregated non-partial response carrying the full content, collected
+// function calls and usage metadata — matching the ADK convention that only
+// the final non-partial event is fully processed downstream.
+func generateGenaiContent(
+	ctx context.Context,
+	client *genai.Client,
+	modelName string,
+	req *model.LLMRequest,
+	stream bool,
+	wrapErr func(error) error,
+) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		config := &genai.GenerateContentConfig{}
+		if req.Config != nil {
+			config = req.Config
+		}
+
+		if !stream {
+			resp, err := client.Models.GenerateContent(ctx, modelName, req.Contents, config)
+			if err != nil {
+				_ = yield(nil, wrapErr(err))
+				return
+			}
+			if len(resp.Candidates) == 0 {
+				_ = yield(nil, wrapErr(fmt.Errorf("no candidates in response")))
+				return
+			}
+			_ = yield(&model.LLMResponse{
+				Content:       resp.Candidates[0].Content,
+				UsageMetadata: resp.UsageMetadata,
+			}, nil)
+			return
+		}
+
+		var (
+			text    strings.Builder
+			fnParts []*genai.Part
+			usage   *genai.GenerateContentResponseUsageMetadata
+		)
+
+		for resp, err := range client.Models.GenerateContentStream(ctx, modelName, req.Contents, config) {
+			if err != nil {
+				_ = yield(nil, wrapErr(err))
+				return
+			}
+			if resp.UsageMetadata != nil {
+				usage = resp.UsageMetadata
+			}
+			if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
+				continue
+			}
+
+			content := resp.Candidates[0].Content
+			hasText := false
+			for _, part := range content.Parts {
+				if part == nil {
+					continue
+				}
+				if part.Text != "" {
+					text.WriteString(part.Text)
+					hasText = true
+				}
+				if part.FunctionCall != nil {
+					fnParts = append(fnParts, part)
+				}
+			}
+
+			if hasText {
+				if !yield(&model.LLMResponse{Content: content, Partial: true}, nil) {
+					return
+				}
+			}
+		}
+
+		parts := make([]*genai.Part, 0, len(fnParts)+1)
+		if text.Len() > 0 {
+			parts = append(parts, genai.NewPartFromText(text.String()))
+		}
+		parts = append(parts, fnParts...)
+		if len(parts) == 0 {
+			_ = yield(nil, wrapErr(fmt.Errorf("no candidates in response")))
+			return
+		}
+
+		_ = yield(&model.LLMResponse{
+			Content:       &genai.Content{Role: "model", Parts: parts},
+			UsageMetadata: usage,
+			TurnComplete:  len(fnParts) == 0,
+		}, nil)
+	}
+}

--- a/internal/infrastructure/agents/llm/ollama/model.go
+++ b/internal/infrastructure/agents/llm/ollama/model.go
@@ -1,6 +1,7 @@
 package ollama
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"google.golang.org/adk/model"
+	"google.golang.org/genai"
 )
 
 // Model implements model.LLM for Ollama
@@ -77,7 +79,7 @@ func (m *Model) Name() string {
 
 // GenerateContent implements model.LLM.GenerateContent
 // Supports:
-// - Simple text generation
+// - Simple text generation (with optional streaming)
 // - Tool calls (function calling)
 // - System instructions
 func (m *Model) GenerateContent(
@@ -90,6 +92,12 @@ func (m *Model) GenerateContent(
 		ollamaReq, err := m.buildRequest(req)
 		if err != nil {
 			_ = yield(nil, fmt.Errorf("error building request: %w", err))
+			return
+		}
+		ollamaReq.Stream = stream
+
+		if stream {
+			m.streamRequest(ctx, ollamaReq, yield)
 			return
 		}
 
@@ -109,6 +117,93 @@ func (m *Model) GenerateContent(
 
 		_ = yield(adkResp, nil)
 	}
+}
+
+// streamRequest executes a streaming call to Ollama (NDJSON lines), yielding
+// each text delta as a Partial response and finishing with one aggregated
+// final response carrying the full message, tool calls and token counts.
+func (m *Model) streamRequest(ctx context.Context, req *ChatRequest, yield func(*model.LLMResponse, error) bool) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		_ = yield(nil, fmt.Errorf("error serializing request: %w", err))
+		return
+	}
+
+	url := m.baseURL + "/api/chat"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		_ = yield(nil, fmt.Errorf("error creating HTTP request: %w", err))
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.client.Do(httpReq)
+	if err != nil {
+		_ = yield(nil, fmt.Errorf("error calling Ollama: %w", err))
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = yield(nil, fmt.Errorf("Ollama returned status %d: %s", resp.StatusCode, string(body)))
+		return
+	}
+
+	var (
+		text      strings.Builder
+		toolCalls []ToolCall
+		final     ChatResponse
+	)
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var chunk ChatResponse
+		if err := json.Unmarshal(line, &chunk); err != nil {
+			_ = yield(nil, fmt.Errorf("error decoding stream chunk: %w", err))
+			return
+		}
+
+		if chunk.Message.Content != "" {
+			text.WriteString(chunk.Message.Content)
+			partial := &model.LLMResponse{
+				Content: &genai.Content{
+					Role:  "model",
+					Parts: []*genai.Part{genai.NewPartFromText(chunk.Message.Content)},
+				},
+				Partial: true,
+			}
+			if !yield(partial, nil) {
+				return
+			}
+		}
+		toolCalls = append(toolCalls, chunk.Message.ToolCalls...)
+
+		if chunk.Done {
+			final = chunk
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		_ = yield(nil, fmt.Errorf("error reading stream: %w", err))
+		return
+	}
+
+	final.Message.Role = "assistant"
+	final.Message.Content = text.String()
+	final.Message.ToolCalls = toolCalls
+
+	adkResp, err := m.buildResponse(&final)
+	if err != nil {
+		_ = yield(nil, fmt.Errorf("error building response: %w", err))
+		return
+	}
+	_ = yield(adkResp, nil)
 }
 
 // doRequest executes HTTP call to Ollama

--- a/internal/infrastructure/agents/llm/ollama/model_test.go
+++ b/internal/infrastructure/agents/llm/ollama/model_test.go
@@ -1,0 +1,122 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+func userRequest(text string) *model.LLMRequest {
+	return &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{genai.NewPartFromText(text)}},
+		},
+	}
+}
+
+func firstText(content *genai.Content) string {
+	for _, part := range content.Parts {
+		if part != nil && part.Text != "" {
+			return part.Text
+		}
+	}
+	return ""
+}
+
+func TestGenerateContentStreamingYieldsPartialsAndFinal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		if !req.Stream {
+			t.Errorf("expected stream=true in request")
+		}
+		lines := []string{
+			`{"message":{"role":"assistant","content":"Hel"},"done":false}`,
+			`{"message":{"role":"assistant","content":"lo"},"done":false}`,
+			`{"message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}`,
+		}
+		for _, line := range lines {
+			_, _ = w.Write([]byte(line + "\n"))
+		}
+	}))
+	defer srv.Close()
+
+	m := NewModel(srv.URL, "test-model")
+
+	var partials []string
+	var final *model.LLMResponse
+	for r, err := range m.GenerateContent(context.Background(), userRequest("hi"), true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if r.Partial {
+			partials = append(partials, firstText(r.Content))
+		} else {
+			final = r
+		}
+	}
+
+	if len(partials) != 2 || partials[0] != "Hel" || partials[1] != "lo" {
+		t.Errorf("unexpected partials: %v", partials)
+	}
+	if final == nil {
+		t.Fatalf("no final response yielded")
+	}
+	if got := firstText(final.Content); got != "Hello" {
+		t.Errorf("final text = %q, want %q", got, "Hello")
+	}
+	if !final.TurnComplete {
+		t.Errorf("final response without tool calls should be TurnComplete")
+	}
+	if final.UsageMetadata == nil || final.UsageMetadata.PromptTokenCount != 10 || final.UsageMetadata.CandidatesTokenCount != 5 {
+		t.Errorf("usage metadata not aggregated: %+v", final.UsageMetadata)
+	}
+}
+
+func TestGenerateContentStreamingCollectsToolCalls(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lines := []string{
+			`{"message":{"role":"assistant","content":"","tool_calls":[{"type":"function","function":{"name":"pumbaa","arguments":{"action":"query"}}}]},"done":false}`,
+			`{"message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":3,"eval_count":2}`,
+		}
+		for _, line := range lines {
+			_, _ = w.Write([]byte(line + "\n"))
+		}
+	}))
+	defer srv.Close()
+
+	m := NewModel(srv.URL, "test-model")
+
+	var final *model.LLMResponse
+	for r, err := range m.GenerateContent(context.Background(), userRequest("hi"), true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !r.Partial {
+			final = r
+		}
+	}
+
+	if final == nil {
+		t.Fatalf("no final response yielded")
+	}
+	var fnCall *genai.FunctionCall
+	for _, part := range final.Content.Parts {
+		if part != nil && part.FunctionCall != nil {
+			fnCall = part.FunctionCall
+		}
+	}
+	if fnCall == nil || fnCall.Name != "pumbaa" {
+		t.Fatalf("tool call not propagated to final response: %+v", final.Content.Parts)
+	}
+	if final.TurnComplete {
+		t.Errorf("final response with pending tool calls should not be TurnComplete")
+	}
+}

--- a/internal/infrastructure/agents/llm/vertex.go
+++ b/internal/infrastructure/agents/llm/vertex.go
@@ -50,41 +50,16 @@ func (m *VertexModel) Name() string {
 	return fmt.Sprintf("vertex/%s", m.modelName)
 }
 
-// GenerateContent implements model.LLM.GenerateContent.
+// GenerateContent implements model.LLM.GenerateContent. Streaming yields
+// Partial responses per chunk followed by one aggregated final response.
 func (m *VertexModel) GenerateContent(
 	ctx context.Context,
 	req *model.LLMRequest,
 	stream bool,
 ) iter.Seq2[*model.LLMResponse, error] {
-	return func(yield func(*model.LLMResponse, error) bool) {
-		// Build the genai request
-		genaiReq := &genai.GenerateContentConfig{}
-
-		if req.Config != nil {
-			genaiReq = req.Config
-		}
-
-		// Use the genai client to generate content
-		resp, err := m.client.Models.GenerateContent(ctx, m.modelName, req.Contents, genaiReq)
-		if err != nil {
-			_ = yield(nil, fmt.Errorf("vertex AI generation failed: %w", err))
-			return
-		}
-
-		// Convert response
-		if len(resp.Candidates) == 0 {
-			_ = yield(nil, fmt.Errorf("no candidates in response"))
-			return
-		}
-
-		candidate := resp.Candidates[0]
-		adkResp := &model.LLMResponse{
-			Content:       candidate.Content,
-			UsageMetadata: resp.UsageMetadata,
-		}
-
-		_ = yield(adkResp, nil)
-	}
+	return generateGenaiContent(ctx, m.client, m.modelName, req, stream, func(err error) error {
+		return fmt.Errorf("vertex AI generation failed: %w", err)
+	})
 }
 
 // Close closes the client connection.

--- a/internal/infrastructure/agents/tools/chatpath_test.go
+++ b/internal/infrastructure/agents/tools/chatpath_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"testing"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/genai"
+)
+
+// chatToolDefinition mirrors the private toolWithDefinition interface the
+// chat uses (internal/interfaces/tui/chat/model.go) to execute tools.
+type chatToolDefinition interface {
+	Declaration() *genai.FunctionDeclaration
+	Run(ctx tool.Context, args any) (map[string]any, error)
+}
+
+// TestChatExecutePathWDL exercises the exact call path the chat uses for a
+// tool call — functiontool.Run with a nil tool.Context and raw map args —
+// so a regression in this layer (not just the registry) fails loudly.
+func TestChatExecutePathWDL(t *testing.T) {
+	all := GetAllTools(nil, stubWDLRepo{})
+
+	var td chatToolDefinition
+	for _, tl := range all {
+		if c, ok := tl.(chatToolDefinition); ok && c.Declaration().Name == "pumbaa" {
+			td = c
+		}
+	}
+	if td == nil {
+		t.Fatal("pumbaa tool does not satisfy the chat's toolWithDefinition interface")
+	}
+
+	for _, args := range []map[string]any{
+		{"action": "wdl_list"},
+		{"action": "wdl_search", "query": "a"},
+	} {
+		result, err := td.Run(NoopToolContext(), args)
+		if err != nil {
+			t.Fatalf("Run(%v) returned error (chat would show ✗): %v", args, err)
+		}
+		if success, _ := result["success"].(bool); !success {
+			t.Fatalf("Run(%v) output not successful: %v", args, result["error"])
+		}
+		t.Logf("%v ok", args)
+	}
+}

--- a/internal/infrastructure/agents/tools/e2e_test.go
+++ b/internal/infrastructure/agents/tools/e2e_test.go
@@ -1,0 +1,131 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+	"github.com/lmtani/pumbaa/internal/infrastructure/cromwell"
+	wdlindexer "github.com/lmtani/pumbaa/internal/infrastructure/wdl"
+)
+
+// TestToolsE2E exercises every built-in agent action against a real Cromwell
+// server and WDL directory. It is the "are the tools actually functional"
+// check, opt-in because it needs live infrastructure:
+//
+//	PUMBAA_TOOLS_E2E=1 CROMWELL_HOST=http://localhost:8000 \
+//	PUMBAA_WDL_DIR=/path/to/workflows \
+//	go test ./internal/infrastructure/agents/tools/ -run TestToolsE2E -v
+func TestToolsE2E(t *testing.T) {
+	if os.Getenv("PUMBAA_TOOLS_E2E") != "1" {
+		t.Skip("set PUMBAA_TOOLS_E2E=1 to run the live tools check")
+	}
+
+	host := os.Getenv("CROMWELL_HOST")
+	if host == "" {
+		host = "http://localhost:8000"
+	}
+	reader := cromwell.NewClient(cromwell.Config{Host: host})
+
+	var wdlRepo *wdlindexer.Indexer
+	if dir := os.Getenv("PUMBAA_WDL_DIR"); dir != "" {
+		var err error
+		wdlRepo, err = wdlindexer.NewIndexer(dir, filepath.Join(t.TempDir(), "index.json"), true)
+		if err != nil {
+			t.Fatalf("failed to build WDL index for %s: %v", dir, err)
+		}
+	}
+
+	registry := tools.NewDefaultRegistry(reader, wdlRepo)
+	ctx := context.Background()
+
+	handle := func(t *testing.T, input types.Input) types.Output {
+		t.Helper()
+		out, err := registry.Handle(ctx, input)
+		if err != nil {
+			t.Fatalf("action %s returned transport error: %v", input.Action, err)
+		}
+		if !out.Success {
+			t.Fatalf("action %s failed: %s", input.Action, out.Error)
+		}
+		return out
+	}
+
+	var workflowID string
+
+	t.Run("query", func(t *testing.T) {
+		out := handle(t, types.Input{Action: "query", PageSize: 3})
+		data, ok := out.Data.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected data shape: %T", out.Data)
+		}
+		wfs, _ := data["workflows"].([]map[string]any)
+		if len(wfs) == 0 {
+			t.Skipf("no workflows on %s; skipping id-dependent actions", host)
+		}
+		workflowID, _ = wfs[0]["id"].(string)
+		t.Logf("query ok: total=%v, using workflow %s", data["total"], workflowID)
+	})
+
+	for _, action := range []string{"status", "metadata", "outputs", "logs"} {
+		t.Run(action, func(t *testing.T) {
+			if workflowID == "" {
+				t.Skip("no workflow id available")
+			}
+			out := handle(t, types.Input{Action: action, WorkflowID: workflowID})
+			t.Logf("%s ok (data type %T)", action, out.Data)
+		})
+	}
+
+	t.Run("gcs_download_bad_path", func(t *testing.T) {
+		// Only the error path: must fail gracefully, never panic or succeed.
+		out, err := registry.Handle(ctx, types.Input{Action: "gcs_download", Path: "gs://pumbaa-e2e-nonexistent-bucket-xyz/nope.txt"})
+		if err != nil {
+			t.Fatalf("gcs_download returned transport error: %v", err)
+		}
+		if out.Success {
+			t.Fatalf("gcs_download of nonexistent object should not succeed")
+		}
+		t.Logf("gcs_download error path ok: %s", out.Error)
+	})
+
+	if wdlRepo == nil {
+		t.Log("PUMBAA_WDL_DIR not set; skipping WDL actions")
+		return
+	}
+
+	var taskName string
+
+	t.Run("wdl_list", func(t *testing.T) {
+		out := handle(t, types.Input{Action: "wdl_list"})
+		data, ok := out.Data.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected data shape: %T", out.Data)
+		}
+		tasks, _ := data["tasks"].([]string)
+		if len(tasks) == 0 {
+			t.Fatalf("wdl_list indexed no tasks from %s", os.Getenv("PUMBAA_WDL_DIR"))
+		}
+		taskName = tasks[0]
+		t.Logf("wdl_list ok: %v tasks, %v workflows", data["task_count"], data["workflow_count"])
+	})
+
+	t.Run("wdl_search", func(t *testing.T) {
+		if taskName == "" {
+			t.Skip("no task name available")
+		}
+		out := handle(t, types.Input{Action: "wdl_search", Query: taskName})
+		t.Logf("wdl_search ok (data type %T)", out.Data)
+	})
+
+	t.Run("wdl_info", func(t *testing.T) {
+		if taskName == "" {
+			t.Skip("no task name available")
+		}
+		out := handle(t, types.Input{Action: "wdl_info", Name: taskName, Type: "task"})
+		t.Logf("wdl_info ok (data type %T)", out.Data)
+	})
+}

--- a/internal/infrastructure/agents/tools/factory.go
+++ b/internal/infrastructure/agents/tools/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lmtani/pumbaa/internal/application/ports"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/cromwell"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/gcs"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/localfs"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/wdl"
 )
@@ -72,6 +73,13 @@ func builtinActions() []actionSpec {
 			description: "Read file from Google Cloud Storage. Required: path (gs://bucket/file).",
 			build: func(_ ports.WorkflowReader, _ wdl.Repository) types.Handler {
 				return gcs.NewDownloadHandler()
+			},
+		},
+		{
+			name:        "write_file",
+			description: "Write a text file (e.g. a bash script to reproduce/debug a task locally) into the user's current working directory. Required: path (relative), content. Optional: executable (true for scripts), overwrite (must be true to replace an existing file).",
+			build: func(_ ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return localfs.NewWriteHandler()
 			},
 		},
 		{

--- a/internal/infrastructure/agents/tools/factory.go
+++ b/internal/infrastructure/agents/tools/factory.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -14,28 +15,104 @@ import (
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/wdl"
 )
 
-// NewDefaultRegistry creates a Registry with all default handlers registered.
-// wdlRepo can be nil if WDL indexing is not configured.
+// actionSpec declares a built-in action of the pumbaa tool: its name, the
+// description surfaced to the LLM, and how to build its handler.
+//
+// This table is the single source of truth for the built-in action set:
+// registration (NewDefaultRegistry), the generated tool description and the
+// parameters-schema enum (schema.go) all derive from it. Adding an action is
+// one entry here — plus a property in GetParametersSchema if the action
+// introduces new parameters.
+type actionSpec struct {
+	name        string
+	description string
+	requiresWDL bool
+	build       func(repo ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler
+}
+
+func builtinActions() []actionSpec {
+	return []actionSpec{
+		{
+			name:        "query",
+			description: "Search Cromwell workflows. Optional: status (Running, Succeeded, Failed, Submitted, Aborted), name.",
+			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return cromwell.NewQueryHandler(repo)
+			},
+		},
+		{
+			name:        "status",
+			description: "Get workflow status. Required: workflow_id.",
+			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return cromwell.NewStatusHandler(repo)
+			},
+		},
+		{
+			name:        "metadata",
+			description: "Get workflow metadata (calls, inputs, outputs). Required: workflow_id.",
+			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return cromwell.NewMetadataHandler(repo)
+			},
+		},
+		{
+			name:        "outputs",
+			description: "Get workflow output files. Required: workflow_id.",
+			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return cromwell.NewOutputsHandler(repo)
+			},
+		},
+		{
+			name:        "logs",
+			description: "Get log file paths for debugging. Required: workflow_id.",
+			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return cromwell.NewLogsHandler(repo)
+			},
+		},
+		{
+			name:        "gcs_download",
+			description: "Read file from Google Cloud Storage. Required: path (gs://bucket/file).",
+			build: func(_ ports.WorkflowReader, _ wdl.Repository) types.Handler {
+				return gcs.NewDownloadHandler()
+			},
+		},
+		{
+			name:        "wdl_list",
+			description: "List all indexed WDL tasks and workflows.",
+			requiresWDL: true,
+			build: func(_ ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler {
+				return wdl.NewListHandler(wdlRepo)
+			},
+		},
+		{
+			name:        "wdl_search",
+			description: "Search tasks/workflows by name or command content. Required: query.",
+			requiresWDL: true,
+			build: func(_ ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler {
+				return wdl.NewSearchHandler(wdlRepo)
+			},
+		},
+		{
+			name:        "wdl_info",
+			description: `Get detailed info about a task or workflow. Required: name, type ("task" or "workflow").`,
+			requiresWDL: true,
+			build: func(_ ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler {
+				return wdl.NewInfoHandler(wdlRepo)
+			},
+		},
+	}
+}
+
+// NewDefaultRegistry creates a Registry with all built-in handlers registered.
+// wdlRepo can be nil if WDL indexing is not configured; WDL actions are then
+// omitted. Callers can Register additional actions on the returned registry
+// before passing it to GetPumbaaTool.
 func NewDefaultRegistry(repo ports.WorkflowReader, wdlRepo wdl.Repository) *Registry {
 	r := NewRegistry()
-
-	// Cromwell actions
-	r.Register("query", cromwell.NewQueryHandler(repo))
-	r.Register("status", cromwell.NewStatusHandler(repo))
-	r.Register("metadata", cromwell.NewMetadataHandler(repo))
-	r.Register("outputs", cromwell.NewOutputsHandler(repo))
-	r.Register("logs", cromwell.NewLogsHandler(repo))
-
-	// GCS actions
-	r.Register("gcs_download", gcs.NewDownloadHandler())
-
-	// WDL actions (only if configured)
-	if wdlRepo != nil {
-		r.Register("wdl_list", wdl.NewListHandler(wdlRepo))
-		r.Register("wdl_search", wdl.NewSearchHandler(wdlRepo))
-		r.Register("wdl_info", wdl.NewInfoHandler(wdlRepo))
+	for _, spec := range builtinActions() {
+		if spec.requiresWDL && wdlRepo == nil {
+			continue
+		}
+		r.Register(spec.name, spec.description, spec.build(repo, wdlRepo))
 	}
-
 	return r
 }
 
@@ -65,42 +142,34 @@ func GetPumbaaTool(registry *Registry) tool.Tool {
 func GetWDLOnlyTools(wdlRepo wdl.Repository) []tool.Tool {
 	r := NewRegistry()
 	if wdlRepo != nil {
-		r.Register("wdl_list", wdl.NewListHandler(wdlRepo))
-		r.Register("wdl_search", wdl.NewSearchHandler(wdlRepo))
-		r.Register("wdl_info", wdl.NewInfoHandler(wdlRepo))
+		for _, spec := range builtinActions() {
+			if spec.requiresWDL {
+				r.Register(spec.name, spec.description, spec.build(nil, wdlRepo))
+			}
+		}
 	}
 	return []tool.Tool{GetPumbaaTool(r)}
 }
 
-// GetAllTools returns all available tools in this package.
-// repo is the workflow repository for API interactions.
-// wdlRepo is the WDL index repository (can be nil if not configured).
-func GetAllTools(repo ports.WorkflowReader, wdlRepo wdl.Repository) []tool.Tool {
+// GetAllTools returns the tools available to the chat agent: the unified
+// pumbaa tool plus any extra ADK tools.
+//
+// repo is the workflow repository for API interactions; wdlRepo is the WDL
+// index repository (nil if not configured). extra is the extension point for
+// adding standalone tools to the agent — each must be an ADK tool exposing
+// Declaration()/Run (e.g. built with functiontool.New).
+func GetAllTools(repo ports.WorkflowReader, wdlRepo wdl.Repository, extra ...tool.Tool) []tool.Tool {
 	registry := NewDefaultRegistry(repo, wdlRepo)
-	return []tool.Tool{
-		GetPumbaaTool(registry),
-	}
+	return append([]tool.Tool{GetPumbaaTool(registry)}, extra...)
 }
 
-// buildDescription generates the tool description based on registered actions.
+// buildDescription generates the tool description from the registered
+// actions, so registration is the only step needed to document an action.
 func buildDescription(registry *Registry) string {
-	baseDescription := `Unified tool for Cromwell workflow management and GCS file access.
-
-Available actions:
-- "query": Search Cromwell workflows. Optional: status (Running, Succeeded, Failed, Submitted, Aborted), name.
-- "status": Get workflow status. Required: workflow_id.
-- "metadata": Get workflow metadata (calls, inputs, outputs). Required: workflow_id.
-- "outputs": Get workflow output files. Required: workflow_id.
-- "logs": Get log file paths for debugging. Required: workflow_id.
-- "gcs_download": Read file from Google Cloud Storage. Required: path (gs://bucket/file).`
-
-	// Check if WDL actions are registered
-	if _, ok := registry.Get("wdl_list"); ok {
-		baseDescription += `
-- "wdl_list": List all indexed WDL tasks and workflows.
-- "wdl_search": Search tasks/workflows by name or command content. Required: query.
-- "wdl_info": Get detailed info about a task or workflow. Required: name, type ("task" or "workflow").`
+	var sb strings.Builder
+	sb.WriteString("Unified tool for Cromwell workflow management and GCS file access.\n\nAvailable actions:")
+	for _, doc := range registry.Docs() {
+		fmt.Fprintf(&sb, "\n- %q: %s", doc.Action, doc.Description)
 	}
-
-	return baseDescription
+	return sb.String()
 }

--- a/internal/infrastructure/agents/tools/factory_test.go
+++ b/internal/infrastructure/agents/tools/factory_test.go
@@ -1,0 +1,120 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/lmtani/pumbaa/internal/domain/wdlindex"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// stubWDLRepo satisfies wdl.Repository for registry construction in tests.
+type stubWDLRepo struct{}
+
+func (stubWDLRepo) List() (*wdlindex.Index, error)                              { return &wdlindex.Index{}, nil }
+func (stubWDLRepo) SearchTasks(string) ([]*wdlindex.IndexedTask, error)         { return nil, nil }
+func (stubWDLRepo) SearchWorkflows(string) ([]*wdlindex.IndexedWorkflow, error) { return nil, nil }
+func (stubWDLRepo) GetTask(string) (*wdlindex.IndexedTask, error)               { return nil, nil }
+func (stubWDLRepo) GetWorkflow(string) (*wdlindex.IndexedWorkflow, error)       { return nil, nil }
+
+func TestNewDefaultRegistryOmitsWDLActionsWithoutRepo(t *testing.T) {
+	r := NewDefaultRegistry(nil, nil)
+
+	for _, action := range []string{"query", "status", "metadata", "outputs", "logs", "gcs_download"} {
+		if _, ok := r.Get(action); !ok {
+			t.Errorf("expected action %q to be registered", action)
+		}
+	}
+	for _, action := range []string{"wdl_list", "wdl_search", "wdl_info"} {
+		if _, ok := r.Get(action); ok {
+			t.Errorf("expected WDL action %q to be omitted without a repository", action)
+		}
+	}
+}
+
+func TestNewDefaultRegistryIncludesWDLActionsWithRepo(t *testing.T) {
+	r := NewDefaultRegistry(nil, stubWDLRepo{})
+
+	for _, action := range []string{"wdl_list", "wdl_search", "wdl_info"} {
+		if _, ok := r.Get(action); !ok {
+			t.Errorf("expected WDL action %q to be registered", action)
+		}
+	}
+}
+
+func TestBuildDescriptionListsRegisteredActions(t *testing.T) {
+	r := NewDefaultRegistry(nil, nil)
+	r.Register("custom_action", "Does something custom. Required: foo.", types.HandlerFunc(
+		func(ctx context.Context, input types.Input) (types.Output, error) {
+			return types.Output{}, nil
+		},
+	))
+
+	desc := buildDescription(r)
+
+	for _, want := range []string{`"query"`, `"custom_action"`, "Does something custom. Required: foo."} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("description missing %q:\n%s", want, desc)
+		}
+	}
+	if strings.Contains(desc, "wdl_list") {
+		t.Errorf("description should not document unregistered WDL actions:\n%s", desc)
+	}
+}
+
+func TestSchemaEnumCoversAllRegisteredActions(t *testing.T) {
+	enum := builtinActionNames()
+	inEnum := make(map[string]bool, len(enum))
+	for _, name := range enum {
+		inEnum[name] = true
+	}
+
+	// Every action a fully-configured registry exposes must be in the enum,
+	// otherwise providers using the explicit schema (Ollama) reject it.
+	r := NewDefaultRegistry(nil, stubWDLRepo{})
+	for _, action := range r.Actions() {
+		if !inEnum[action] {
+			t.Errorf("action %q registered but missing from schema enum", action)
+		}
+	}
+}
+
+func TestGetAllToolsAppendsExtras(t *testing.T) {
+	extra, err := functiontool.New(
+		functiontool.Config{Name: "my_tool", Description: "test tool"},
+		func(ctx tool.Context, input struct{}) (map[string]any, error) {
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("failed to build extra tool: %v", err)
+	}
+
+	all := GetAllTools(nil, nil, extra)
+
+	if len(all) != 2 {
+		t.Fatalf("expected pumbaa tool + 1 extra, got %d tools", len(all))
+	}
+	if all[1] != extra {
+		t.Errorf("extra tool not passed through")
+	}
+}
+
+func TestRegistryHandleUnknownActionListsValidOnes(t *testing.T) {
+	r := NewDefaultRegistry(nil, nil)
+
+	out, err := r.Handle(context.Background(), types.Input{Action: "nope"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Success {
+		t.Fatalf("expected error output for unknown action")
+	}
+	if !strings.Contains(out.Error, "query") {
+		t.Errorf("error should list valid actions, got: %s", out.Error)
+	}
+}

--- a/internal/infrastructure/agents/tools/localfs/write.go
+++ b/internal/infrastructure/agents/tools/localfs/write.go
@@ -1,0 +1,94 @@
+// Package localfs provides action handlers for writing files in the user's
+// working directory — e.g. debug scripts the agent generates on request
+// (fetch task inputs with gsutil, reproduce an analysis locally with docker).
+package localfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// WriteHandler handles the "write_file" action.
+type WriteHandler struct{}
+
+// NewWriteHandler creates a new WriteHandler.
+func NewWriteHandler() *WriteHandler {
+	return &WriteHandler{}
+}
+
+// Handle implements types.Handler.
+func (h *WriteHandler) Handle(_ context.Context, input types.Input) (types.Output, error) {
+	const action = "write_file"
+
+	if strings.TrimSpace(input.Content) == "" {
+		return types.NewErrorOutput(action, "content is required"), nil
+	}
+
+	fullPath, err := resolveWorkingDirPath(input.Path)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	if _, err := os.Stat(fullPath); err == nil && !input.Overwrite {
+		return types.NewErrorOutput(action, fmt.Sprintf(
+			"file already exists: %s. Pass overwrite=true to replace it, or choose another name.",
+			input.Path,
+		)), nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		return types.NewErrorOutput(action, fmt.Sprintf("failed to create directory: %v", err)), nil
+	}
+
+	perm := os.FileMode(0o644)
+	if input.Executable {
+		perm = 0o755
+	}
+	if err := os.WriteFile(fullPath, []byte(input.Content), perm); err != nil {
+		return types.NewErrorOutput(action, fmt.Sprintf("failed to write file: %v", err)), nil
+	}
+	if input.Executable {
+		// WriteFile's perm only applies on creation; ensure the bit on overwrite
+		if err := os.Chmod(fullPath, 0o755); err != nil {
+			return types.NewErrorOutput(action, fmt.Sprintf("failed to mark file executable: %v", err)), nil
+		}
+	}
+
+	return types.NewSuccessOutput(action, map[string]any{
+		"path":       fullPath,
+		"bytes":      len(input.Content),
+		"executable": input.Executable,
+	}), nil
+}
+
+// resolveWorkingDirPath validates that the requested path stays inside the
+// user's current working directory and returns its absolute form. The agent
+// must never write outside the directory pumbaa was launched from.
+func resolveWorkingDirPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required (relative to the current working directory)")
+	}
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("path must be relative to the current working directory, got absolute path %q", path)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve working directory: %v", err)
+	}
+
+	fullPath := filepath.Clean(filepath.Join(cwd, path))
+	if fullPath == cwd {
+		return "", fmt.Errorf("path %q resolves to the working directory itself, not a file", path)
+	}
+	if !strings.HasPrefix(fullPath, cwd+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %q escapes the current working directory", path)
+	}
+
+	return fullPath, nil
+}

--- a/internal/infrastructure/agents/tools/localfs/write_test.go
+++ b/internal/infrastructure/agents/tools/localfs/write_test.go
@@ -1,0 +1,112 @@
+package localfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// chdir switches to a temp dir for the test, since the handler writes
+// relative to the process working directory.
+func chdir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+	// Resolve symlinks (macOS /tmp) so comparisons match os.Getwd
+	resolved, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func TestWriteFileCreatesScript(t *testing.T) {
+	dir := chdir(t)
+	h := NewWriteHandler()
+
+	out, err := h.Handle(context.Background(), types.Input{
+		Action:     "write_file",
+		Path:       "debug/reproduce.sh",
+		Content:    "#!/bin/bash\ngsutil cp gs://bucket/input .\n",
+		Executable: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Success {
+		t.Fatalf("expected success, got: %s", out.Error)
+	}
+
+	full := filepath.Join(dir, "debug", "reproduce.sh")
+	info, err := os.Stat(full)
+	if err != nil {
+		t.Fatalf("file not written: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("expected executable bit, got mode %v", info.Mode())
+	}
+	data, _ := os.ReadFile(full)
+	if !strings.Contains(string(data), "gsutil cp") {
+		t.Errorf("unexpected content: %s", data)
+	}
+}
+
+func TestWriteFileRefusesOverwriteWithoutFlag(t *testing.T) {
+	chdir(t)
+	h := NewWriteHandler()
+
+	first, _ := h.Handle(context.Background(), types.Input{Path: "a.sh", Content: "one"})
+	if !first.Success {
+		t.Fatalf("first write failed: %s", first.Error)
+	}
+
+	second, _ := h.Handle(context.Background(), types.Input{Path: "a.sh", Content: "two"})
+	if second.Success {
+		t.Fatalf("expected refusal to overwrite without flag")
+	}
+
+	third, _ := h.Handle(context.Background(), types.Input{Path: "a.sh", Content: "two", Overwrite: true})
+	if !third.Success {
+		t.Fatalf("overwrite with flag failed: %s", third.Error)
+	}
+	data, _ := os.ReadFile("a.sh")
+	if string(data) != "two" {
+		t.Errorf("content not replaced: %s", data)
+	}
+}
+
+func TestWriteFileRejectsUnsafePaths(t *testing.T) {
+	chdir(t)
+	h := NewWriteHandler()
+
+	for _, path := range []string{"", "/etc/passwd", "../outside.sh", "sub/../../outside.sh", "."} {
+		out, err := h.Handle(context.Background(), types.Input{Path: path, Content: "x"})
+		if err != nil {
+			t.Fatalf("unexpected transport error for %q: %v", path, err)
+		}
+		if out.Success {
+			t.Errorf("expected rejection for path %q", path)
+		}
+	}
+}
+
+func TestWriteFileRequiresContent(t *testing.T) {
+	chdir(t)
+	h := NewWriteHandler()
+
+	out, _ := h.Handle(context.Background(), types.Input{Path: "empty.sh", Content: "  "})
+	if out.Success {
+		t.Fatalf("expected rejection of empty content")
+	}
+}

--- a/internal/infrastructure/agents/tools/noop_context.go
+++ b/internal/infrastructure/agents/tools/noop_context.go
@@ -1,0 +1,23 @@
+package tools
+
+import (
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/toolconfirmation"
+)
+
+// noopToolContext is a minimal tool.Context for invoking function tools
+// outside an ADK runner — the TUI chat drives its own agent loop instead of
+// using the ADK Runner, which normally supplies the context.
+//
+// Only the methods touched by functiontool.Run's happy path are implemented:
+// ToolConfirmation returning nil selects the no-confirmation branch (ADK
+// v1.0.0 panics on a nil Context here). Any other method call hits the nil
+// embedded interface and panics — functiontool recovers it into a tool error,
+// so a future ADK version that needs more context fails loudly, not silently.
+type noopToolContext struct{ tool.Context }
+
+func (noopToolContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return nil }
+
+// NoopToolContext returns the context to use when executing tools directly
+// (outside an ADK runner).
+func NoopToolContext() tool.Context { return noopToolContext{} }

--- a/internal/infrastructure/agents/tools/registry.go
+++ b/internal/infrastructure/agents/tools/registry.go
@@ -8,35 +8,54 @@ import (
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
 )
 
+// entry couples an action handler with its LLM-facing description.
+type entry struct {
+	handler     types.Handler
+	description string
+}
+
+// ActionDoc describes a registered action for LLM-facing documentation.
+type ActionDoc struct {
+	Action      string
+	Description string
+}
+
 // Registry manages the mapping between action names and their handlers.
-// It provides a clean extension point for adding new actions without modifying existing code.
+// It provides a clean extension point for adding new actions without
+// modifying existing code: the tool description shown to the LLM is
+// generated from the registered actions and their descriptions.
 type Registry struct {
-	handlers map[string]types.Handler
+	entries map[string]entry
 }
 
 // NewRegistry creates a new empty Registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		handlers: make(map[string]types.Handler),
+		entries: make(map[string]entry),
 	}
 }
 
-// Register adds a handler for the given action name.
+// Register adds a handler for the given action name. The description is
+// surfaced to the LLM in the tool documentation, so state what the action
+// does and which parameters it requires (e.g. "Required: workflow_id.").
 // If a handler already exists for this action, it will be replaced.
-func (r *Registry) Register(action string, handler types.Handler) {
-	r.handlers[action] = handler
+func (r *Registry) Register(action, description string, handler types.Handler) {
+	r.entries[action] = entry{handler: handler, description: description}
 }
 
 // RegisterFunc is a convenience method to register a function as a handler.
-func (r *Registry) RegisterFunc(action string, fn types.HandlerFunc) {
-	r.handlers[action] = fn
+func (r *Registry) RegisterFunc(action, description string, fn types.HandlerFunc) {
+	r.Register(action, description, fn)
 }
 
 // Get returns the handler for the given action.
 // Returns nil and false if no handler is registered.
 func (r *Registry) Get(action string) (types.Handler, bool) {
-	h, ok := r.handlers[action]
-	return h, ok
+	e, ok := r.entries[action]
+	if !ok {
+		return nil, false
+	}
+	return e.handler, true
 }
 
 // Handle dispatches the input to the appropriate handler based on the action.
@@ -55,15 +74,26 @@ func (r *Registry) Handle(ctx context.Context, input types.Input) (types.Output,
 
 // Actions returns a sorted list of all registered action names.
 func (r *Registry) Actions() []string {
-	actions := make([]string, 0, len(r.handlers))
-	for action := range r.handlers {
+	actions := make([]string, 0, len(r.entries))
+	for action := range r.entries {
 		actions = append(actions, action)
 	}
 	sort.Strings(actions)
 	return actions
 }
 
+// Docs returns the registered actions with their descriptions, sorted by
+// action name. Used to generate the tool description shown to the LLM.
+func (r *Registry) Docs() []ActionDoc {
+	docs := make([]ActionDoc, 0, len(r.entries))
+	for action, e := range r.entries {
+		docs = append(docs, ActionDoc{Action: action, Description: e.description})
+	}
+	sort.Slice(docs, func(i, j int) bool { return docs[i].Action < docs[j].Action })
+	return docs
+}
+
 // Count returns the number of registered handlers.
 func (r *Registry) Count() int {
-	return len(r.handlers)
+	return len(r.entries)
 }

--- a/internal/infrastructure/agents/tools/schema.go
+++ b/internal/infrastructure/agents/tools/schema.go
@@ -29,7 +29,19 @@ func GetParametersSchema() map[string]any {
 			},
 			"path": map[string]any{
 				"type":        "string",
-				"description": "GCS path (gs://bucket/file) for gcs_download action",
+				"description": "GCS path (gs://bucket/file) for gcs_download, or relative file path for write_file",
+			},
+			"content": map[string]any{
+				"type":        "string",
+				"description": "File body for write_file action",
+			},
+			"executable": map[string]any{
+				"type":        "boolean",
+				"description": "Mark the written file as executable (write_file action)",
+			},
+			"overwrite": map[string]any{
+				"type":        "boolean",
+				"description": "Allow write_file to replace an existing file",
 			},
 			"query": map[string]any{
 				"type":        "string",

--- a/internal/infrastructure/agents/tools/schema.go
+++ b/internal/infrastructure/agents/tools/schema.go
@@ -12,7 +12,7 @@ func GetParametersSchema() map[string]any {
 			"action": map[string]any{
 				"type":        "string",
 				"description": "The action to perform",
-				"enum":        []string{"query", "status", "metadata", "outputs", "logs", "gcs_download", "wdl_list", "wdl_search", "wdl_info"},
+				"enum":        builtinActionNames(),
 			},
 			"workflow_id": map[string]any{
 				"type":        "string",
@@ -47,6 +47,17 @@ func GetParametersSchema() map[string]any {
 		},
 		"required": []string{"action"},
 	}
+}
+
+// builtinActionNames returns the names of all built-in actions for the
+// schema enum, derived from the same table that drives registration.
+func builtinActionNames() []string {
+	specs := builtinActions()
+	names := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		names = append(names, spec.name)
+	}
+	return names
 }
 
 // Re-export types for backward compatibility with external packages

--- a/internal/infrastructure/agents/tools/tools.go
+++ b/internal/infrastructure/agents/tools/tools.go
@@ -1,12 +1,35 @@
 // Package tools provides implementations of tools for use with Google Agents ADK.
 //
-// This package follows the Registry pattern to allow easy extension with new actions.
-// To add a new action:
+// There are two extension points for giving the chat agent new capabilities:
 //
-//  1. Create a new handler struct in the appropriate subpackage (cromwell/, gcs/, wdl/)
-//  2. Implement the ActionHandler interface
-//  3. Register the handler in NewDefaultRegistry() in factory.go
-//  4. Update GetParametersSchema() in schema.go if the action needs new parameters
+// # Adding an action to the pumbaa tool
+//
+// Actions are sub-commands of the unified "pumbaa" tool, dispatched through
+// the Registry. The builtinActions table in factory.go is the single source
+// of truth: registration, the LLM-facing tool description and the
+// parameters-schema enum all derive from it. To add an action:
+//
+//  1. Create a handler in the appropriate subpackage (cromwell/, gcs/, wdl/)
+//     implementing types.Handler
+//  2. Add one entry to builtinActions() in factory.go with the action name
+//     and a description stating its required/optional parameters
+//  3. Only if the action introduces new parameters: add the property to
+//     GetParametersSchema() in schema.go
+//
+// Callers building a custom registry can also register ad-hoc actions:
+//
+//	registry := tools.NewDefaultRegistry(repo, nil)
+//	registry.Register("my_action", "Does something. Required: foo.", myHandler)
+//	agentTools := []tool.Tool{tools.GetPumbaaTool(registry)}
+//
+// # Adding a standalone ADK tool
+//
+// Independent tools (their own name and schema, not a pumbaa action) are
+// passed through GetAllTools' variadic parameter and flow into the chat
+// agent untouched:
+//
+//	myTool, _ := functiontool.New(functiontool.Config{Name: "my_tool", ...}, run)
+//	agentTools := tools.GetAllTools(repo, nil, myTool)
 //
 // Example handler:
 //
@@ -14,8 +37,8 @@
 //
 //	func NewMyHandler() *MyHandler { return &MyHandler{} }
 //
-//	func (h *MyHandler) Handle(ctx context.Context, input tools.PumbaaInput) (tools.PumbaaOutput, error) {
+//	func (h *MyHandler) Handle(ctx context.Context, input types.Input) (types.Output, error) {
 //	    // implementation
-//	    return tools.NewSuccessOutput("my_action", data), nil
+//	    return types.NewSuccessOutput("my_action", data), nil
 //	}
 package tools

--- a/internal/infrastructure/agents/tools/types/types.go
+++ b/internal/infrastructure/agents/tools/types/types.go
@@ -31,6 +31,15 @@ type Input struct {
 
 	// PageSize for query action (default: 10).
 	PageSize int `json:"page_size,omitempty"`
+
+	// Content is the file body for the write_file action.
+	Content string `json:"content,omitempty"`
+
+	// Executable marks the written file as executable (write_file action).
+	Executable bool `json:"executable,omitempty"`
+
+	// Overwrite allows write_file to replace an existing file.
+	Overwrite bool `json:"overwrite,omitempty"`
 }
 
 // Output represents the standardized output for all actions.

--- a/internal/infrastructure/cromwell/cost_validation_test.go
+++ b/internal/infrastructure/cromwell/cost_validation_test.go
@@ -1,0 +1,60 @@
+package cromwell
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestCostBreakdownMatchesAPI validates the per-task cost reconstruction
+// (domain CalculateCostBreakdown, fed through the real metadata mapper)
+// against Cromwell's authoritative /cost total. Opt-in: point it at a saved
+// expanded-metadata JSON and the API cost.
+//
+//	PUMBAA_COST_VALIDATE=/path/to/expanded_metadata.json \
+//	PUMBAA_COST_EXPECTED=5.6765 \
+//	go test ./internal/infrastructure/cromwell/ -run TestCostBreakdownMatchesAPI -v
+func TestCostBreakdownMatchesAPI(t *testing.T) {
+	path := os.Getenv("PUMBAA_COST_VALIDATE")
+	if path == "" {
+		t.Skip("set PUMBAA_COST_VALIDATE to an expanded-metadata JSON to run")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+
+	client := NewClient(Config{Host: "http://unused"})
+	wf, err := client.ParseMetadata(data)
+	if err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+
+	b := wf.CalculateCostBreakdown()
+	t.Logf("reconstructed total: $%.4f across %d tasks (pending subs: %d)",
+		b.TotalCost, len(b.Tasks), b.SubworkflowsPending)
+	for i, tc := range b.Tasks {
+		if i >= 5 {
+			break
+		}
+		t.Logf("  %-40s $%.2f (%.1f%%, %.1fh, preempt=%v)", tc.Name, tc.TotalCost, tc.Percent, tc.VMHours, tc.Preemptible)
+	}
+
+	expected := os.Getenv("PUMBAA_COST_EXPECTED")
+	if expected == "" {
+		return
+	}
+	var want float64
+	if _, err := fmt.Sscanf(expected, "%g", &want); err != nil {
+		t.Fatalf("bad PUMBAA_COST_EXPECTED: %v", err)
+	}
+	// Allow 2% drift: our estimate uses call Start/End while Cromwell's cost
+	// may use slightly different VM lifetime boundaries.
+	diff := b.TotalCost - want
+	if diff < 0 {
+		diff = -diff
+	}
+	if want > 0 && diff/want > 0.02 {
+		t.Errorf("reconstructed $%.4f differs from API $%.4f by %.1f%% (>2%%)", b.TotalCost, want, 100*diff/want)
+	}
+}

--- a/internal/infrastructure/session/sqlite.go
+++ b/internal/infrastructure/session/sqlite.go
@@ -19,6 +19,14 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// DefaultAppName and DefaultUserID scope all Pumbaa chat sessions. Every
+// entry point (standalone chat, embedded TUI chat, session lists) must use
+// these constants so conversations are visible and resumable everywhere.
+const (
+	DefaultAppName = "pumbaa"
+	DefaultUserID  = "default"
+)
+
 // SQLiteService implements session.Service using SQLite for persistence.
 type SQLiteService struct {
 	db *sql.DB
@@ -174,6 +182,16 @@ func (s *SQLiteService) initSchema() error {
 
 	// Migration: add summary column if it doesn't exist (for existing databases)
 	s.db.Exec(`ALTER TABLE sessions ADD COLUMN summary TEXT DEFAULT ''`)
+
+	// Migration: add context_label (which workflow ▸ task the chat was
+	// opened for) to support resume-by-task lookups
+	s.db.Exec(`ALTER TABLE sessions ADD COLUMN context_label TEXT DEFAULT ''`)
+
+	// Hygiene: purge day-old sessions that never got a single event
+	// (artifacts of sessions being created on screen open, pre-lazy-create)
+	s.db.Exec(`DELETE FROM sessions
+		WHERE created_at < datetime('now', '-1 day')
+		  AND id NOT IN (SELECT DISTINCT session_id FROM events)`)
 
 	return nil
 }
@@ -449,11 +467,53 @@ func (s *SQLiteService) UpdateTokenUsage(ctx context.Context, sessionID string, 
 type SessionInfo struct {
 	ID           string
 	Summary      string
+	ContextLabel string // Which workflow ▸ task the chat was opened for
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	InputTokens  int
 	OutputTokens int
 	EventCount   int
+}
+
+// SetContextLabel tags a session with the task context it was opened for
+// (e.g. "my-workflow ▸ align_reads"), enabling resume-by-task lookups.
+func (s *SQLiteService) SetContextLabel(ctx context.Context, sessionID, label string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.ExecContext(ctx, `UPDATE sessions SET context_label = ? WHERE id = ?`, label, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to set context label: %w", err)
+	}
+	return nil
+}
+
+// FindLatestByContextLabel returns the most recent session that has events
+// for the given context label, or nil if there is none.
+func (s *SQLiteService) FindLatestByContextLabel(ctx context.Context, appName, userID, label string) (*SessionInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	row := s.db.QueryRowContext(ctx, `
+		SELECT s.id, s.summary, s.context_label, s.created_at, s.updated_at, s.input_tokens, s.output_tokens,
+		       (SELECT COUNT(*) FROM events e WHERE e.session_id = s.id) AS event_count
+		FROM sessions s
+		WHERE s.app_name = ? AND s.user_id = ? AND s.context_label = ?
+		  AND EXISTS (SELECT 1 FROM events e WHERE e.session_id = s.id)
+		ORDER BY s.updated_at DESC
+		LIMIT 1`,
+		appName, userID, label,
+	)
+
+	var info SessionInfo
+	err := row.Scan(&info.ID, &info.Summary, &info.ContextLabel, &info.CreatedAt, &info.UpdatedAt, &info.InputTokens, &info.OutputTokens, &info.EventCount)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find session by context: %w", err)
+	}
+	return &info, nil
 }
 
 // UpdateSummary updates the summary for a session.
@@ -478,7 +538,7 @@ func (s *SQLiteService) ListWithSummaries(ctx context.Context, appName, userID s
 	defer s.mu.RUnlock()
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, summary, created_at, updated_at, input_tokens, output_tokens FROM sessions WHERE app_name = ? AND user_id = ? ORDER BY updated_at DESC`,
+		`SELECT id, summary, context_label, created_at, updated_at, input_tokens, output_tokens FROM sessions WHERE app_name = ? AND user_id = ? ORDER BY updated_at DESC`,
 		appName, userID,
 	)
 	if err != nil {
@@ -489,7 +549,7 @@ func (s *SQLiteService) ListWithSummaries(ctx context.Context, appName, userID s
 	var sessions []SessionInfo
 	for rows.Next() {
 		var info SessionInfo
-		if err := rows.Scan(&info.ID, &info.Summary, &info.CreatedAt, &info.UpdatedAt, &info.InputTokens, &info.OutputTokens); err != nil {
+		if err := rows.Scan(&info.ID, &info.Summary, &info.ContextLabel, &info.CreatedAt, &info.UpdatedAt, &info.InputTokens, &info.OutputTokens); err != nil {
 			return nil, fmt.Errorf("failed to scan session: %w", err)
 		}
 

--- a/internal/infrastructure/session/sqlite_test.go
+++ b/internal/infrastructure/session/sqlite_test.go
@@ -1,0 +1,90 @@
+package session
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+func newTestService(t *testing.T) *SQLiteService {
+	t.Helper()
+	svc, err := NewSQLiteService(filepath.Join(t.TempDir(), "sessions.db"))
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+	t.Cleanup(func() { svc.Close() })
+	return svc
+}
+
+func TestFindLatestByContextLabel(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	resp, err := svc.Create(ctx, &session.CreateRequest{AppName: DefaultAppName, UserID: DefaultUserID})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if err := svc.SetContextLabel(ctx, resp.Session.ID(), "wf ▸ align"); err != nil {
+		t.Fatalf("set context label failed: %v", err)
+	}
+
+	// Sessions without events must not be offered for resume
+	info, err := svc.FindLatestByContextLabel(ctx, DefaultAppName, DefaultUserID, "wf ▸ align")
+	if err != nil {
+		t.Fatalf("find failed: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("expected no resumable session before any event, got %s", info.ID)
+	}
+
+	ev := session.NewEvent("")
+	ev.Author = "user"
+	ev.Content = &genai.Content{Role: "user", Parts: []*genai.Part{genai.NewPartFromText("why did it fail?")}}
+	if err := svc.AppendEvent(ctx, resp.Session, ev); err != nil {
+		t.Fatalf("append event failed: %v", err)
+	}
+
+	info, err = svc.FindLatestByContextLabel(ctx, DefaultAppName, DefaultUserID, "wf ▸ align")
+	if err != nil {
+		t.Fatalf("find failed: %v", err)
+	}
+	if info == nil {
+		t.Fatalf("expected resumable session after event")
+	}
+	if info.ID != resp.Session.ID() || info.ContextLabel != "wf ▸ align" || info.EventCount != 1 {
+		t.Errorf("unexpected info: %+v", info)
+	}
+
+	// Different label finds nothing
+	other, err := svc.FindLatestByContextLabel(ctx, DefaultAppName, DefaultUserID, "wf ▸ other_task")
+	if err != nil {
+		t.Fatalf("find failed: %v", err)
+	}
+	if other != nil {
+		t.Errorf("expected no session for a different label, got %s", other.ID)
+	}
+}
+
+func TestListWithSummariesIncludesContextLabel(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	resp, err := svc.Create(ctx, &session.CreateRequest{AppName: DefaultAppName, UserID: DefaultUserID})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if err := svc.SetContextLabel(ctx, resp.Session.ID(), "wf ▸ merge"); err != nil {
+		t.Fatalf("set context label failed: %v", err)
+	}
+
+	sessions, err := svc.ListWithSummaries(ctx, DefaultAppName, DefaultUserID)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ContextLabel != "wf ▸ merge" {
+		t.Errorf("context label not returned in list: %+v", sessions)
+	}
+}

--- a/internal/interfaces/cli/handler/chat.go
+++ b/internal/interfaces/cli/handler/chat.go
@@ -65,9 +65,22 @@ status, failures, logs, outputs, or runtime metadata.
 
 Use **only** to read real files produced by executions.
 
-- action="gcs_download"  
-  Read file from GCS  
+- action="gcs_download"
+  Read file from GCS
   Required: path (gs://bucket/file)
+
+---
+
+## 2b. Local files (user's working directory)
+
+Use to save scripts or files the user asks for — e.g. a bash script that
+fetches a task's inputs with gsutil and reruns the analysis locally with
+docker for debugging.
+
+- action="write_file"
+  Write a text file relative to the current working directory
+  Required: path (relative), content
+  Optional: executable=true for scripts, overwrite=true to replace
 
 ---
 

--- a/internal/interfaces/cli/handler/chat.go
+++ b/internal/interfaces/cli/handler/chat.go
@@ -13,15 +13,14 @@ import (
 	"github.com/lmtani/pumbaa/internal/config"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/llm"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools"
-	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/wdl"
 	"github.com/lmtani/pumbaa/internal/infrastructure/session"
 	"github.com/lmtani/pumbaa/internal/infrastructure/telemetry"
-	wdlindexer "github.com/lmtani/pumbaa/internal/infrastructure/wdl"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/chat"
 )
 
-const appName = "pumbaa"
-const defaultUserID = "default"
+// Session scope shared with the embedded TUI chat (see session package).
+const appName = session.DefaultAppName
+const defaultUserID = session.DefaultUserID
 
 const systemInstruction = `You are Pumbaa, a helpful assistant specialized in bioinformatics workflows and Cromwell/WDL.
 
@@ -234,9 +233,12 @@ func (h *ChatHandler) ListSessions() error {
 		if summary == "" {
 			summary = "(no summary)"
 		}
-		// Truncate summary to 50 chars for display
-		if len(summary) > 50 {
-			summary = summary[:47] + "..."
+		if s.ContextLabel != "" {
+			summary = s.ContextLabel + ": " + summary
+		}
+		// Truncate summary to 60 chars for display
+		if len(summary) > 60 {
+			summary = summary[:57] + "..."
 		}
 		fmt.Printf("  - %-20s │ %s │ %s\n",
 			s.ID[:20],
@@ -282,21 +284,7 @@ func (h *ChatHandler) Run(sessionID string, rebuildIndex bool) error {
 	h.telemetry.AddBreadcrumb("chat", fmt.Sprintf("using LLM provider: %s", h.config.LLMProvider))
 	fmt.Printf("Using LLM: %s | Cromwell: %s\n", llmModel.Name(), h.config.CromwellHost)
 
-	// Initialize WDL indexer if configured
-	var wdlRepo wdl.Repository
-	if h.config.WDLDirectory != "" {
-		fmt.Printf("Indexing WDL workflows from: %s\n", h.config.WDLDirectory)
-		indexer, err := wdlindexer.NewIndexer(h.config.WDLDirectory, h.config.WDLIndexPath, rebuildIndex)
-		if err != nil {
-			fmt.Printf("Warning: Failed to initialize WDL indexer: %v\n", err)
-		} else {
-			wdlRepo = indexer
-			idx, _ := indexer.List()
-			fmt.Printf("WDL index: %d tasks, %d workflows\n", len(idx.Tasks), len(idx.Workflows))
-		}
-	}
-
-	agentTools := tools.GetAllTools(h.repository, wdlRepo)
+	agentTools := tools.GetAllTools(h.repository, initWDLRepository(h.config, rebuildIndex))
 	m := chat.NewModel(llmModel, agentTools, systemInstruction, svc, sess)
 	m.SetStandalone(true) // Running directly from CLI, not embedded in TUI
 

--- a/internal/interfaces/cli/handler/chat_deps.go
+++ b/internal/interfaces/cli/handler/chat_deps.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"google.golang.org/adk/tool"
+
 	"github.com/lmtani/pumbaa/internal/application/ports"
 	"github.com/lmtani/pumbaa/internal/config"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/llm"
@@ -14,7 +16,10 @@ import (
 
 // initChatDependencies creates the optional chat dependencies for TUI screens.
 // Returns nil if LLM or session initialization fails (chat is silently disabled).
-func initChatDependencies(cfg *config.Config, repo ports.WorkflowReader) *tui.ChatDependencies {
+//
+// extraTools is the extension point for adding standalone ADK tools to the
+// chat agent beyond the built-in pumbaa tool; see the tools package docs.
+func initChatDependencies(cfg *config.Config, repo ports.WorkflowReader, extraTools ...tool.Tool) *tui.ChatDependencies {
 	llmModel, err := llm.NewLLM(cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Chat disabled - LLM initialization failed: %v\n", err)
@@ -27,7 +32,7 @@ func initChatDependencies(cfg *config.Config, repo ports.WorkflowReader) *tui.Ch
 		return nil
 	}
 
-	agentTools := tools.GetAllTools(repo, nil)
+	agentTools := tools.GetAllTools(repo, nil, extraTools...)
 
 	return &tui.ChatDependencies{
 		LLM:        llmModel,

--- a/internal/interfaces/cli/handler/chat_deps.go
+++ b/internal/interfaces/cli/handler/chat_deps.go
@@ -10,9 +10,29 @@ import (
 	"github.com/lmtani/pumbaa/internal/config"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/llm"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/wdl"
 	"github.com/lmtani/pumbaa/internal/infrastructure/session"
+	wdlindexer "github.com/lmtani/pumbaa/internal/infrastructure/wdl"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui"
 )
+
+// initWDLRepository builds the WDL index repository from config. Returns nil
+// (WDL actions disabled) when no directory is configured or indexing fails.
+// The index is cached at cfg.WDLIndexPath, so subsequent startups are instant.
+func initWDLRepository(cfg *config.Config, forceRebuild bool) wdl.Repository {
+	if cfg.WDLDirectory == "" {
+		return nil
+	}
+	indexer, err := wdlindexer.NewIndexer(cfg.WDLDirectory, cfg.WDLIndexPath, forceRebuild)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: WDL tools disabled - indexing failed: %v\n", err)
+		return nil
+	}
+	if idx, err := indexer.List(); err == nil {
+		fmt.Printf("WDL index: %d tasks, %d workflows\n", len(idx.Tasks), len(idx.Workflows))
+	}
+	return indexer
+}
 
 // initChatDependencies creates the optional chat dependencies for TUI screens.
 // Returns nil if LLM or session initialization fails (chat is silently disabled).
@@ -32,7 +52,7 @@ func initChatDependencies(cfg *config.Config, repo ports.WorkflowReader, extraTo
 		return nil
 	}
 
-	agentTools := tools.GetAllTools(repo, nil, extraTools...)
+	agentTools := tools.GetAllTools(repo, initWDLRepository(cfg, false), extraTools...)
 
 	return &tui.ChatDependencies{
 		LLM:        llmModel,

--- a/internal/interfaces/cli/handler/dashboard.go
+++ b/internal/interfaces/cli/handler/dashboard.go
@@ -109,6 +109,7 @@ func (h *DashboardHandler) createDependencies() *tui.Dependencies {
 		FileProvider:   h.fileProvider,
 		MonitoringUC:   h.monitoringUC,
 		BatchLogsUC:    h.batchLogsUC,
+		CompareUC:      workflowapp.NewCompareUseCase(h.repository),
 		CurrentVersion: h.version,
 	}
 

--- a/internal/interfaces/cli/handler/dashboard.go
+++ b/internal/interfaces/cli/handler/dashboard.go
@@ -91,6 +91,7 @@ func (h *DashboardHandler) handle(c *cli.Context) error {
 
 	// Create and run the program
 	p := tea.NewProgram(model, tea.WithAltScreen())
+	deps.Program = p // Lets screens push messages from goroutines (streaming)
 	_, err := p.Run()
 	if err != nil {
 		h.telemetry.CaptureError("dashboard.tui", err)

--- a/internal/interfaces/cli/handler/debug.go
+++ b/internal/interfaces/cli/handler/debug.go
@@ -139,6 +139,7 @@ func (h *DebugHandler) handle(c *cli.Context) error {
 
 	// Create and run the program
 	p := tea.NewProgram(model, tea.WithAltScreen())
+	deps.Program = p // Lets screens push messages from goroutines (streaming)
 	_, err = p.Run()
 	if err != nil {
 		h.telemetry.CaptureError("debug.tui", err)

--- a/internal/interfaces/cli/handler/metadata.go
+++ b/internal/interfaces/cli/handler/metadata.go
@@ -34,14 +34,7 @@ func (h *MetadataHandler) Command() *cli.Command {
 		Aliases:   []string{"m", "meta"},
 		Usage:     "Get workflow metadata and display status",
 		ArgsUsage: "<workflow-id>",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "verbose",
-				Aliases: []string{"v"},
-				Usage:   "[optional] Show detailed call information",
-			},
-		},
-		Action: h.handle,
+		Action:    h.handle,
 	}
 }
 
@@ -64,12 +57,12 @@ func (h *MetadataHandler) handle(c *cli.Context) error {
 		return err
 	}
 
-	h.displayMetadata(output, c.Bool("verbose"))
+	h.displayMetadata(output)
 
 	return nil
 }
 
-func (h *MetadataHandler) displayMetadata(wf *workflowdomain.Workflow, verbose bool) {
+func (h *MetadataHandler) displayMetadata(wf *workflowdomain.Workflow) {
 	// Workflow overview
 	h.presenter.Title("Workflow Details")
 	h.presenter.KeyValue("ID", wf.ID)

--- a/internal/interfaces/tui/app.go
+++ b/internal/interfaces/tui/app.go
@@ -65,7 +65,7 @@ func NewAppModel(deps *Dependencies, initialScreen Screen) AppModel {
 	}
 
 	// Initialize dashboard
-	m.dashboard = dashboard.NewModelWithRepository(deps.Repository, deps.CurrentVersion)
+	m.dashboard = dashboard.NewModelWithRepository(deps.Repository, deps.CompareUC, deps.CurrentVersion)
 	m.hasDashboard = true
 
 	return m

--- a/internal/interfaces/tui/app.go
+++ b/internal/interfaces/tui/app.go
@@ -31,8 +31,11 @@ const (
 )
 
 // chatSessionCreatedMsg carries the result of the asynchronous chat session
-// creation started when navigating to the chat screen.
+// creation started when navigating to the chat screen. target identifies the
+// chat instance that requested it, so a slow create from a previous visit
+// can never attach to a newer conversation.
 type chatSessionCreatedMsg struct {
+	target  *chat.Model
 	session adksession.Session
 	err     error
 }
@@ -127,9 +130,11 @@ func (m AppModel) Init() tea.Cmd {
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		// Only the visible screen needs to re-layout; hidden screens get the
+		// size replayed (sizeCmd) when they become current again.
 		m.width = msg.Width
 		m.height = msg.Height
-		return m.broadcast(msg)
+		return m.updateCurrentScreen(msg)
 
 	case tea.KeyMsg:
 		// Handle quit confirmation modal first
@@ -157,7 +162,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.navigateBack()
 
 	case chatSessionCreatedMsg:
-		if m.chat != nil {
+		if m.chat != nil && m.chat == msg.target {
 			if msg.err != nil {
 				m.chat.AddInfoMessage("Session persistence unavailable: " + msg.err.Error())
 			} else {
@@ -209,12 +214,11 @@ func (m AppModel) navigateToDebug(wf *workflow.Workflow) (tea.Model, tea.Cmd) {
 	// Reuse the existing model when the workflow is unchanged so tree
 	// expansion, cursor, search and watch state survive the round trip.
 	if wf == m.debugWorkflow {
-		return m, m.sizeCmd()
+		return m, tea.Batch(m.sizeCmd(), m.debug.ResumeCmd())
 	}
 
 	m.debugWorkflow = wf
 	m.debug = newDebugModel(m.deps, wf)
-	m.debug.SetCanGoBack(true)
 
 	return m, tea.Batch(m.debug.Init(), m.sizeCmd())
 }
@@ -248,11 +252,12 @@ func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.C
 		m.chat.AddInfoMessage(msg.ContextSummary)
 	}
 
-	return m, tea.Batch(m.chat.Init(), m.sizeCmd(), m.createChatSessionCmd())
+	return m, tea.Batch(m.chat.Init(), m.sizeCmd(), m.createChatSessionCmd(m.chat))
 }
 
-// createChatSessionCmd creates the chat session off the UI thread.
-func (m AppModel) createChatSessionCmd() tea.Cmd {
+// createChatSessionCmd creates the chat session off the UI thread for the
+// given chat instance.
+func (m AppModel) createChatSessionCmd(target *chat.Model) tea.Cmd {
 	svc := m.deps.ChatDeps.SessionSvc
 	if svc == nil {
 		return nil
@@ -263,9 +268,9 @@ func (m AppModel) createChatSessionCmd() tea.Cmd {
 			UserID:  debugChatUserID,
 		})
 		if err != nil {
-			return chatSessionCreatedMsg{err: err}
+			return chatSessionCreatedMsg{target: target, err: err}
 		}
-		return chatSessionCreatedMsg{session: resp.Session}
+		return chatSessionCreatedMsg{target: target, session: resp.Session}
 	}
 }
 
@@ -279,8 +284,16 @@ func (m AppModel) navigateBack() (tea.Model, tea.Cmd) {
 	m.currentScreen = m.stack[len(m.stack)-1]
 	m.stack = m.stack[:len(m.stack)-1]
 
-	// Returning screens kept their state; they only need the current size.
-	return m, m.sizeCmd()
+	// Returning screens kept their state; they only need the current size
+	// and, if they were mid-load, a fresh spinner tick.
+	var resume tea.Cmd
+	switch m.currentScreen {
+	case ScreenDashboard:
+		resume = m.dashboard.ResumeCmd()
+	case ScreenDebug:
+		resume = m.debug.ResumeCmd()
+	}
+	return m, tea.Batch(m.sizeCmd(), resume)
 }
 
 // sizeCmd replays the last known window size to the (new) current screen.
@@ -294,15 +307,13 @@ func (m AppModel) sizeCmd() tea.Cmd {
 	}
 }
 
-// hasOngoingWork reports whether quitting now would interrupt background work.
+// hasOngoingWork reports whether quitting now would interrupt background
+// work on any screen — hidden screens keep working after navigation.
 func (m AppModel) hasOngoingWork() bool {
-	switch m.currentScreen {
-	case ScreenDebug:
-		return m.debug.HasOngoingWork()
-	case ScreenChat:
-		return m.chat != nil && m.chat.IsBusy()
+	if m.debugWorkflow != nil && m.debug.HasOngoingWork() {
+		return true
 	}
-	return false
+	return m.chat != nil && m.chat.IsBusy()
 }
 
 // updateCurrentScreen delegates the update to the current screen.

--- a/internal/interfaces/tui/app.go
+++ b/internal/interfaces/tui/app.go
@@ -2,12 +2,9 @@
 package tui
 
 import (
-	"context"
-
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	adksession "google.golang.org/adk/session"
 
 	"github.com/lmtani/pumbaa/internal/domain/workflow"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/chat"
@@ -24,21 +21,6 @@ const (
 	ScreenDebug
 	ScreenChat
 )
-
-const (
-	debugChatAppName = "pumbaa-debug"
-	debugChatUserID  = "default"
-)
-
-// chatSessionCreatedMsg carries the result of the asynchronous chat session
-// creation started when navigating to the chat screen. target identifies the
-// chat instance that requested it, so a slow create from a previous visit
-// can never attach to a newer conversation.
-type chatSessionCreatedMsg struct {
-	target  *chat.Model
-	session adksession.Session
-	err     error
-}
 
 // AppModel is the root model that coordinates navigation between screens.
 //
@@ -166,16 +148,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case common.NavigateBackMsg:
 		return m.navigateBack()
-
-	case chatSessionCreatedMsg:
-		if m.chat != nil && m.chat == msg.target {
-			if msg.err != nil {
-				m.chat.AddInfoMessage("Session persistence unavailable: " + msg.err.Error())
-			} else {
-				m.chat.SetSession(msg.session)
-			}
-		}
-		return m, nil
 	}
 
 	// Keys and spinner frames concern only the focused screen. Everything
@@ -264,7 +236,7 @@ func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.C
 		m.deps.ChatDeps.Tools,
 		msg.SystemInstruction,
 		m.deps.ChatDeps.SessionSvc,
-		nil, // session attaches asynchronously via chatSessionCreatedMsg
+		nil, // the chat creates its session lazily on the first message
 	)
 	m.chat = &chatModel
 	m.chatContextLabel = msg.ContextLabel
@@ -279,26 +251,7 @@ func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.C
 		m.chat.AddInfoMessage(msg.ContextSummary)
 	}
 
-	return m, tea.Batch(m.chat.Init(), m.sizeCmd(), m.createChatSessionCmd(m.chat))
-}
-
-// createChatSessionCmd creates the chat session off the UI thread for the
-// given chat instance.
-func (m AppModel) createChatSessionCmd(target *chat.Model) tea.Cmd {
-	svc := m.deps.ChatDeps.SessionSvc
-	if svc == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		resp, err := svc.Create(context.Background(), &adksession.CreateRequest{
-			AppName: debugChatAppName,
-			UserID:  debugChatUserID,
-		})
-		if err != nil {
-			return chatSessionCreatedMsg{target: target, err: err}
-		}
-		return chatSessionCreatedMsg{target: target, session: resp.Session}
-	}
+	return m, tea.Batch(m.chat.Init(), m.sizeCmd())
 }
 
 // navigateBack pops the navigation stack; at the root it starts the quit flow.

--- a/internal/interfaces/tui/app.go
+++ b/internal/interfaces/tui/app.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	adksession "google.golang.org/adk/session"
 
@@ -29,42 +30,36 @@ const (
 	debugChatUserID  = "default"
 )
 
-// Navigation messages - these are used to navigate between screens
-
-// NavigateToDebugMsg requests navigation to the debug screen.
-type NavigateToDebugMsg struct {
-	Workflow *workflow.Workflow
+// chatSessionCreatedMsg carries the result of the asynchronous chat session
+// creation started when navigating to the chat screen.
+type chatSessionCreatedMsg struct {
+	session adksession.Session
+	err     error
 }
-
-// NavigateToChatMsg requests navigation to the chat screen.
-type NavigateToChatMsg struct {
-	SystemInstruction string
-	ContextSummary    string
-}
-
-// NavigateBackMsg requests navigation back to the previous screen.
-type NavigateBackMsg struct{}
-
-// NavigateToDashboardMsg requests navigation back to the dashboard.
-type NavigateToDashboardMsg struct{}
 
 // AppModel is the root model that coordinates navigation between screens.
+//
+// Screens are self-contained: they handle their own keys (including ESC) and
+// request navigation by emitting the common.Navigate* messages. AppModel only
+// switches screens, keeps the navigation stack, and owns the quit flow.
 type AppModel struct {
-	currentScreen  Screen
-	previousScreen Screen
-	startScreen    Screen // The screen we started on (for determining if ESC should quit or go back)
-	dashboard      dashboard.Model
-	debug          debug.Model
-	chat           *chat.Model
-	width          int
-	height         int
-	globalKeys     common.GlobalKeys
-	deps           *Dependencies
+	currentScreen Screen
+	stack         []Screen // Screens to return to on NavigateBackMsg
 
-	// State for preserving context during navigation
-	lastWorkflow        *workflow.Workflow
-	lastChatInstruction string
-	lastChatSummary     string
+	dashboard    dashboard.Model
+	hasDashboard bool // False when started directly on the debug screen
+	debug        debug.Model
+	chat         *chat.Model
+
+	// debugWorkflow is the workflow currently loaded in the debug screen; it
+	// lets navigateToDebug reuse the model (preserving cursor, expansion,
+	// search and watch state) when the target workflow hasn't changed.
+	debugWorkflow *workflow.Workflow
+
+	width      int
+	height     int
+	globalKeys common.GlobalKeys
+	deps       *Dependencies
 
 	// Quit confirmation modal
 	showQuitConfirm bool
@@ -74,13 +69,13 @@ type AppModel struct {
 func NewAppModel(deps *Dependencies, initialScreen Screen) AppModel {
 	m := AppModel{
 		currentScreen: initialScreen,
-		startScreen:   initialScreen,
 		globalKeys:    common.DefaultGlobalKeys(),
 		deps:          deps,
 	}
 
 	// Initialize dashboard
 	m.dashboard = dashboard.NewModelWithRepository(deps.Repository, deps.CurrentVersion)
+	m.hasDashboard = true
 
 	return m
 }
@@ -89,14 +84,21 @@ func NewAppModel(deps *Dependencies, initialScreen Screen) AppModel {
 func NewAppModelWithWorkflow(deps *Dependencies, wf *workflow.Workflow) AppModel {
 	m := AppModel{
 		currentScreen: ScreenDebug,
-		startScreen:   ScreenDebug,
 		globalKeys:    common.DefaultGlobalKeys(),
 		deps:          deps,
-		lastWorkflow:  wf,
+		debugWorkflow: wf,
 	}
 
-	// Initialize debug directly
-	m.debug = debug.NewModelWithChat(
+	m.debug = newDebugModel(deps, wf)
+	// Started directly on debug: there is no dashboard to go back to
+	m.debug.SetCanGoBack(false)
+
+	return m
+}
+
+// newDebugModel builds a debug screen model for the given workflow.
+func newDebugModel(deps *Dependencies, wf *workflow.Workflow) debug.Model {
+	return debug.NewModelWithChat(
 		wf,
 		deps.Repository,
 		deps.MonitoringUC,
@@ -104,11 +106,6 @@ func NewAppModelWithWorkflow(deps *Dependencies, wf *workflow.Workflow) AppModel
 		deps.BatchLogsUC,
 		convertChatDeps(deps.ChatDeps),
 	)
-
-	// Since we're starting directly on debug, ESC should quit, not go back
-	m.debug.SetCanGoBack(false)
-
-	return m
 }
 
 // Init implements tea.Model.
@@ -132,8 +129,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		// Propagate to current screen
-		return m.updateCurrentScreen(msg)
+		return m.broadcast(msg)
 
 	case tea.KeyMsg:
 		// Handle quit confirmation modal first
@@ -141,148 +137,172 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleQuitConfirmKeys(msg)
 		}
 
-		// Ctrl+C shows quit confirmation
+		// Ctrl+C quits immediately; confirmation is only worth the friction
+		// when background work would be interrupted.
 		if key.Matches(msg, m.globalKeys.Quit) {
-			m.showQuitConfirm = true
-			return m, nil
+			if m.hasOngoingWork() {
+				m.showQuitConfirm = true
+				return m, nil
+			}
+			return m, tea.Quit
 		}
 
-		// ESC handling: delegate to screen first, then handle back navigation
-		if msg.Type == tea.KeyEsc {
-			return m.handleEscapeKey()
-		}
-
-	// Handle navigation messages
-	case NavigateToDebugMsg:
+	case common.NavigateToDebugMsg:
 		return m.navigateToDebug(msg.Workflow)
 
-	// Handle navigation from dashboard (different package, same message type)
-	case dashboard.NavigateToDebugMsg:
-		return m.navigateToDebug(msg.Workflow)
+	case common.NavigateToChatMsg:
+		return m.navigateToChat(msg)
 
-	case NavigateToChatMsg:
-		return m.navigateToChat(msg.SystemInstruction, msg.ContextSummary)
-
-	// Handle navigation from debug (different package)
-	case debug.NavigateToChatMsg:
-		return m.navigateToChat(msg.SystemInstruction, msg.ContextSummary)
-
-	case NavigateBackMsg:
+	case common.NavigateBackMsg:
 		return m.navigateBack()
 
-	case NavigateToDashboardMsg:
-		return m.navigateToDashboard()
+	case chatSessionCreatedMsg:
+		if m.chat != nil {
+			if msg.err != nil {
+				m.chat.AddInfoMessage("Session persistence unavailable: " + msg.err.Error())
+			} else {
+				m.chat.SetSession(msg.session)
+			}
+		}
+		return m, nil
 	}
 
-	return m.updateCurrentScreen(msg)
+	// Keys and spinner frames concern only the focused screen. Everything
+	// else (async results, timers) is broadcast so hidden screens keep
+	// working — e.g. watch mode keeps refreshing while the user is in chat.
+	switch msg.(type) {
+	case tea.KeyMsg, spinner.TickMsg:
+		return m.updateCurrentScreen(msg)
+	}
+	return m.broadcast(msg)
+}
+
+// broadcast forwards a message to every initialized screen. Screen message
+// types are package-private, so there is no cross-talk between screens.
+func (m AppModel) broadcast(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	if m.hasDashboard {
+		newModel, cmd := m.dashboard.Update(msg)
+		m.dashboard = newModel.(dashboard.Model)
+		cmds = append(cmds, cmd)
+	}
+	if m.debugWorkflow != nil {
+		newModel, cmd := m.debug.Update(msg)
+		m.debug = newModel.(debug.Model)
+		cmds = append(cmds, cmd)
+	}
+	if m.chat != nil {
+		newModel, cmd := m.chat.Update(msg)
+		m.chat = newModel.(*chat.Model)
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
 }
 
 // navigateToDebug switches to the debug screen with the given workflow.
 func (m AppModel) navigateToDebug(wf *workflow.Workflow) (tea.Model, tea.Cmd) {
-	m.previousScreen = m.currentScreen
+	m.stack = append(m.stack, m.currentScreen)
 	m.currentScreen = ScreenDebug
-	m.lastWorkflow = wf
 
-	m.debug = debug.NewModelWithChat(
-		wf,
-		m.deps.Repository,
-		m.deps.MonitoringUC,
-		m.deps.FileProvider,
-		m.deps.BatchLogsUC,
-		convertChatDeps(m.deps.ChatDeps),
-	)
-
-	// Send window size to new screen
-	cmd := m.debug.Init()
-	if m.width > 0 && m.height > 0 {
-		sizeCmd := func() tea.Msg {
-			return tea.WindowSizeMsg{Width: m.width, Height: m.height}
-		}
-		return m, tea.Batch(cmd, sizeCmd)
+	// Reuse the existing model when the workflow is unchanged so tree
+	// expansion, cursor, search and watch state survive the round trip.
+	if wf == m.debugWorkflow {
+		return m, m.sizeCmd()
 	}
-	return m, cmd
+
+	m.debugWorkflow = wf
+	m.debug = newDebugModel(m.deps, wf)
+	m.debug.SetCanGoBack(true)
+
+	return m, tea.Batch(m.debug.Init(), m.sizeCmd())
 }
 
-// navigateToChat switches to the chat screen.
-func (m AppModel) navigateToChat(systemInstruction, contextSummary string) (tea.Model, tea.Cmd) {
-	if m.deps.ChatDeps == nil || m.deps.ChatDeps.LLM == nil {
-		// Chat not available, stay on current screen
+// navigateToChat switches to the chat screen. The chat session is created
+// asynchronously so the UI never blocks on network or disk.
+func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.Cmd) {
+	if !m.deps.HasChat() {
+		// Screens guard against this before emitting the message; ignore.
 		return m, nil
 	}
 
-	m.previousScreen = m.currentScreen
+	m.stack = append(m.stack, m.currentScreen)
 	m.currentScreen = ScreenChat
-	m.lastChatInstruction = systemInstruction
-	m.lastChatSummary = contextSummary
-
-	// Create chat session
-	ctx := context.Background()
-	var sess adksession.Session
-	if m.deps.ChatDeps.SessionSvc != nil {
-		resp, err := m.deps.ChatDeps.SessionSvc.Create(ctx, &adksession.CreateRequest{
-			AppName: debugChatAppName,
-			UserID:  debugChatUserID,
-		})
-		if err == nil {
-			sess = resp.Session
-		}
-	}
 
 	chatModel := chat.NewModel(
 		m.deps.ChatDeps.LLM,
 		m.deps.ChatDeps.Tools,
-		systemInstruction,
+		msg.SystemInstruction,
 		m.deps.ChatDeps.SessionSvc,
-		sess,
+		nil, // session attaches asynchronously via chatSessionCreatedMsg
 	)
 	m.chat = &chatModel
-	m.chat.SetContextLabel("Task Context")
-	if contextSummary != "" {
-		m.chat.AddInfoMessage(contextSummary)
+
+	label := msg.ContextLabel
+	if label == "" {
+		label = "Task Context"
+	}
+	m.chat.SetContextLabel(label)
+	if msg.ContextSummary != "" {
+		m.chat.AddInfoMessage(msg.ContextSummary)
 	}
 
-	cmd := m.chat.Init()
-	if m.width > 0 && m.height > 0 {
-		sizeCmd := func() tea.Msg {
-			return tea.WindowSizeMsg{Width: m.width, Height: m.height}
-		}
-		return m, tea.Batch(cmd, sizeCmd)
-	}
-	return m, cmd
+	return m, tea.Batch(m.chat.Init(), m.sizeCmd(), m.createChatSessionCmd())
 }
 
-// navigateBack returns to the previous screen.
-func (m AppModel) navigateBack() (tea.Model, tea.Cmd) {
-	switch m.previousScreen {
-	case ScreenDashboard:
-		return m.navigateToDashboard()
-	case ScreenDebug:
-		if m.lastWorkflow != nil {
-			return m.navigateToDebug(m.lastWorkflow)
-		}
-		return m.navigateToDashboard()
-	default:
-		return m.navigateToDashboard()
+// createChatSessionCmd creates the chat session off the UI thread.
+func (m AppModel) createChatSessionCmd() tea.Cmd {
+	svc := m.deps.ChatDeps.SessionSvc
+	if svc == nil {
+		return nil
 	}
-}
-
-// navigateToDashboard returns to the dashboard screen (preserving state).
-func (m AppModel) navigateToDashboard() (tea.Model, tea.Cmd) {
-	m.previousScreen = m.currentScreen
-	m.currentScreen = ScreenDashboard
-
-	// Dashboard maintains state, just send window size
-	var cmds []tea.Cmd
-	if m.width > 0 && m.height > 0 {
-		cmds = append(cmds, func() tea.Msg {
-			return tea.WindowSizeMsg{Width: m.width, Height: m.height}
+	return func() tea.Msg {
+		resp, err := svc.Create(context.Background(), &adksession.CreateRequest{
+			AppName: debugChatAppName,
+			UserID:  debugChatUserID,
 		})
+		if err != nil {
+			return chatSessionCreatedMsg{err: err}
+		}
+		return chatSessionCreatedMsg{session: resp.Session}
+	}
+}
+
+// navigateBack pops the navigation stack; at the root it starts the quit flow.
+func (m AppModel) navigateBack() (tea.Model, tea.Cmd) {
+	if len(m.stack) == 0 {
+		m.showQuitConfirm = true
+		return m, nil
 	}
 
-	if len(cmds) > 0 {
-		return m, tea.Batch(cmds...)
+	m.currentScreen = m.stack[len(m.stack)-1]
+	m.stack = m.stack[:len(m.stack)-1]
+
+	// Returning screens kept their state; they only need the current size.
+	return m, m.sizeCmd()
+}
+
+// sizeCmd replays the last known window size to the (new) current screen.
+func (m AppModel) sizeCmd() tea.Cmd {
+	if m.width == 0 || m.height == 0 {
+		return nil
 	}
-	return m, nil
+	width, height := m.width, m.height
+	return func() tea.Msg {
+		return tea.WindowSizeMsg{Width: width, Height: height}
+	}
+}
+
+// hasOngoingWork reports whether quitting now would interrupt background work.
+func (m AppModel) hasOngoingWork() bool {
+	switch m.currentScreen {
+	case ScreenDebug:
+		return m.debug.HasOngoingWork()
+	case ScreenChat:
+		return m.chat != nil && m.chat.IsBusy()
+	}
+	return false
 }
 
 // updateCurrentScreen delegates the update to the current screen.
@@ -291,37 +311,11 @@ func (m AppModel) updateCurrentScreen(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ScreenDashboard:
 		newModel, cmd := m.dashboard.Update(msg)
 		m.dashboard = newModel.(dashboard.Model)
-
-		// Check for navigation request from dashboard
-		if navCmd := m.dashboard.GetNavigationCmd(); navCmd != nil {
-			m.dashboard.ClearNavigation()
-			// Execute the command and handle the resulting message
-			return m, navCmd
-		}
-
-		// Check if dashboard wants to quit
-		if m.dashboard.ShouldQuit {
-			return m, tea.Quit
-		}
-
 		return m, cmd
 
 	case ScreenDebug:
 		newModel, cmd := m.debug.Update(msg)
 		m.debug = newModel.(debug.Model)
-
-		// Check for back navigation from debug
-		if m.debug.ShouldGoBack() {
-			m.debug.ClearNavigation()
-			return m.navigateToDashboard()
-		}
-
-		// Check for navigation request from debug (to chat)
-		if navCmd := m.debug.GetNavigationCmd(); navCmd != nil {
-			m.debug.ClearNavigation()
-			return m, navCmd
-		}
-
 		return m, cmd
 
 	case ScreenChat:
@@ -330,18 +324,6 @@ func (m AppModel) updateCurrentScreen(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		newModel, cmd := m.chat.Update(msg)
 		m.chat = newModel.(*chat.Model)
-
-		// Check for quit from chat
-		if m.chat.ShouldQuit() {
-			return m, tea.Quit
-		}
-
-		// Check for back navigation from chat
-		if m.chat.ShouldGoBack() {
-			m.chat.ClearNavigation()
-			return m.navigateBack()
-		}
-
 		return m, cmd
 	}
 
@@ -351,76 +333,11 @@ func (m AppModel) updateCurrentScreen(msg tea.Msg) (tea.Model, tea.Cmd) {
 // handleQuitConfirmKeys handles key presses when quit confirmation modal is shown.
 func (m AppModel) handleQuitConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "y", "Y":
+	case "y", "Y", "ctrl+c":
 		return m, tea.Quit
 	case "n", "N", "esc":
 		m.showQuitConfirm = false
 	}
-	return m, nil
-}
-
-// handleEscapeKey handles ESC key press with the new navigation flow.
-func (m AppModel) handleEscapeKey() (tea.Model, tea.Cmd) {
-	// Check if current screen has a modal open or can handle ESC internally
-	switch m.currentScreen {
-	case ScreenDebug:
-		// Check if debug has a modal open
-		if m.debug.HasActiveModal() {
-			// Let debug handle it
-			return m.updateCurrentScreen(tea.KeyMsg{Type: tea.KeyEsc})
-		}
-		// If debug is in search mode, let it handle to exit search
-		if m.debug.IsSearchActive() {
-			return m.updateCurrentScreen(tea.KeyMsg{Type: tea.KeyEsc})
-		}
-		// If debug is in a non-tree view mode, let it handle to return to tree view
-		if m.debug.GetViewMode() != debug.ViewModeTree {
-			return m.updateCurrentScreen(tea.KeyMsg{Type: tea.KeyEsc})
-		}
-		// If we started on debug, show quit confirmation (no dashboard to go back to)
-		if m.startScreen == ScreenDebug {
-			m.showQuitConfirm = true
-			return m, nil
-		}
-		// Otherwise, go back to dashboard
-		return m.navigateToDashboard()
-
-	case ScreenChat:
-		if m.chat != nil {
-			// If chat has a modal, let it handle
-			if m.chat.HasActiveModal() {
-				return m.updateCurrentScreen(tea.KeyMsg{Type: tea.KeyEsc})
-			}
-			// If in FocusInput, switch to FocusMessages
-			if m.chat.GetFocusMode() == chat.FocusInput {
-				m.chat.SetFocusMode(chat.FocusMessages)
-				return m, nil
-			}
-			// If we started on chat, show quit confirmation
-			if m.startScreen == ScreenChat {
-				m.showQuitConfirm = true
-				return m, nil
-			}
-			// In FocusMessages, go back
-			return m.navigateBack()
-		}
-		// If we started on chat, show quit confirmation
-		if m.startScreen == ScreenChat {
-			m.showQuitConfirm = true
-			return m, nil
-		}
-		return m.navigateBack()
-
-	case ScreenDashboard:
-		// If dashboard has a modal open, let it handle ESC
-		if m.dashboard.HasActiveModal() {
-			return m.updateCurrentScreen(tea.KeyMsg{Type: tea.KeyEsc})
-		}
-		// Dashboard is root - show quit confirmation
-		m.showQuitConfirm = true
-		return m, nil
-	}
-
 	return m, nil
 }
 
@@ -459,9 +376,14 @@ func (m AppModel) renderWithQuitModal() string {
 		}
 	}
 
+	body := "Are you sure you want to exit?"
+	if m.hasOngoingWork() {
+		body = "Background work is still running.\nQuit anyway?"
+	}
+
 	// Create the modal
 	modalContent := common.TitleStyle.Render("Quit Pumbaa?") + "\n\n" +
-		"Are you sure you want to exit?\n\n" +
+		body + "\n\n" +
 		common.KeyStyle.Render("[Y]") + " " + common.DescStyle.Render("Yes, quit") + "    " +
 		common.KeyStyle.Render("[N]") + " " + common.DescStyle.Render("No, stay")
 

--- a/internal/interfaces/tui/app.go
+++ b/internal/interfaces/tui/app.go
@@ -54,6 +54,12 @@ type AppModel struct {
 	debug        debug.Model
 	chat         *chat.Model
 
+	// chatContextLabel/chatInstruction identify the conversation currently
+	// loaded in the chat screen, so re-entering the chat for the same task
+	// resumes it instead of starting over.
+	chatContextLabel string
+	chatInstruction  string
+
 	// debugWorkflow is the workflow currently loaded in the debug screen; it
 	// lets navigateToDebug reuse the model (preserving cursor, expansion,
 	// search and watch state) when the target workflow hasn't changed.
@@ -225,6 +231,10 @@ func (m AppModel) navigateToDebug(wf *workflow.Workflow) (tea.Model, tea.Cmd) {
 
 // navigateToChat switches to the chat screen. The chat session is created
 // asynchronously so the UI never blocks on network or disk.
+//
+// Re-entering the chat for the same task (same context label) resumes the
+// live conversation instead of starting a new one; freshly collected context
+// only replaces the system instruction.
 func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.Cmd) {
 	if !m.deps.HasChat() {
 		// Screens guard against this before emitting the message; ignore.
@@ -234,6 +244,21 @@ func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.C
 	m.stack = append(m.stack, m.currentScreen)
 	m.currentScreen = ScreenChat
 
+	label := msg.ContextLabel
+	if label == "" {
+		label = "Task Context"
+	}
+
+	// Same task: resume the existing conversation
+	if m.chat != nil && msg.ContextLabel != "" && msg.ContextLabel == m.chatContextLabel {
+		if msg.SystemInstruction != m.chatInstruction {
+			m.chatInstruction = msg.SystemInstruction
+			m.chat.SetSystemInstruction(msg.SystemInstruction)
+			m.chat.AppendNotice("Context refreshed for " + label)
+		}
+		return m, tea.Batch(m.sizeCmd(), m.chat.ResumeCmd())
+	}
+
 	chatModel := chat.NewModel(
 		m.deps.ChatDeps.LLM,
 		m.deps.ChatDeps.Tools,
@@ -242,10 +267,12 @@ func (m AppModel) navigateToChat(msg common.NavigateToChatMsg) (tea.Model, tea.C
 		nil, // session attaches asynchronously via chatSessionCreatedMsg
 	)
 	m.chat = &chatModel
+	m.chatContextLabel = msg.ContextLabel
+	m.chatInstruction = msg.SystemInstruction
 
-	label := msg.ContextLabel
-	if label == "" {
-		label = "Task Context"
+	if m.deps.Program != nil {
+		// Enables streaming and tool records pushed from the generation goroutine
+		m.chat.SetProgram(m.deps.Program)
 	}
 	m.chat.SetContextLabel(label)
 	if msg.ContextSummary != "" {

--- a/internal/interfaces/tui/chat/modal_sessions.go
+++ b/internal/interfaces/tui/chat/modal_sessions.go
@@ -52,10 +52,8 @@ func (m *Model) loadSessionsList() tea.Cmd {
 
 		// Cast sessionService to SQLiteService to access ListWithSummaries
 		if svc, ok := m.sessionService.(*infraSession.SQLiteService); ok {
-			const appName = "pumbaa"
-			const defaultUserID = "default"
 
-			sessions, err := svc.ListWithSummaries(ctx, appName, defaultUserID)
+			sessions, err := svc.ListWithSummaries(ctx, infraSession.DefaultAppName, infraSession.DefaultUserID)
 			if err != nil {
 				return sessionListErrorMsg{err: err}
 			}
@@ -75,7 +73,8 @@ func (m *Model) getFilteredSessions() []infraSession.SessionInfo {
 	var filtered []infraSession.SessionInfo
 	for _, sess := range m.sessionsList {
 		if strings.Contains(strings.ToLower(sess.ID), search) ||
-			strings.Contains(strings.ToLower(sess.Summary), search) {
+			strings.Contains(strings.ToLower(sess.Summary), search) ||
+			strings.Contains(strings.ToLower(sess.ContextLabel), search) {
 			filtered = append(filtered, sess)
 		}
 	}
@@ -173,10 +172,13 @@ func (m *Model) formatSessionLine(sess infraSession.SessionInfo, selected bool) 
 		idDisplay = common.Truncate(idDisplay, 16)
 	}
 
-	// Truncate summary to 30 chars
+	// Description: task context (when present) + summary, truncated to 30
 	summary := sess.Summary
 	if summary == "" {
 		summary = "(no summary)"
+	}
+	if sess.ContextLabel != "" {
+		summary = sess.ContextLabel + ": " + summary
 	}
 	if len(summary) > 30 {
 		summary = common.Truncate(summary, 30)
@@ -340,12 +342,10 @@ func (m *Model) switchToSession(sessionID string) (tea.Model, tea.Cmd) {
 
 		// Load new session
 		if svc, ok := m.sessionService.(*infraSession.SQLiteService); ok {
-			const appName = "pumbaa"
-			const defaultUserID = "default"
 
 			resp, err := svc.Get(ctx, &session.GetRequest{
-				AppName:   appName,
-				UserID:    defaultUserID,
+				AppName:   infraSession.DefaultAppName,
+				UserID:    infraSession.DefaultUserID,
 				SessionID: sessionID,
 			})
 			if err != nil {
@@ -396,12 +396,10 @@ func (m *Model) createNewSession() (tea.Model, tea.Cmd) {
 
 		// Create new session
 		if svc, ok := m.sessionService.(*infraSession.SQLiteService); ok {
-			const appName = "pumbaa"
-			const defaultUserID = "default"
 
 			resp, err := svc.Create(ctx, &session.CreateRequest{
-				AppName: appName,
-				UserID:  defaultUserID,
+				AppName: infraSession.DefaultAppName,
+				UserID:  infraSession.DefaultUserID,
 			})
 			if err != nil {
 				return sessionListErrorMsg{err: err}

--- a/internal/interfaces/tui/chat/model.go
+++ b/internal/interfaces/tui/chat/model.go
@@ -2,12 +2,15 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -125,6 +128,13 @@ type Model struct {
 	statusMessage    string    // Temporary status message (e.g., "Copied!")
 	statusExpires    time.Time // When status message expires
 
+	// Streaming state: text of the in-progress response, shown live at the
+	// end of the transcript until the final ResponseMsg replaces it.
+	streamingText string
+
+	// cancelGen aborts the in-flight generation (ESC while loading).
+	cancelGen context.CancelFunc
+
 	// Token usage tracking
 	inputTokens  int // Accumulated input tokens for the session
 	outputTokens int // Accumulated output tokens for the session
@@ -176,6 +186,20 @@ type ToolNotificationMsg struct {
 	owner *[]ChatMessage // See ResponseMsg.owner
 }
 
+// streamChunkMsg carries the accumulated text of the current turn while the
+// response is streaming.
+type streamChunkMsg struct {
+	owner *[]ChatMessage
+	text  string
+}
+
+// toolRecordMsg appends a persistent record of an executed tool call to the
+// transcript (unlike ToolNotificationMsg, which is transient).
+type toolRecordMsg struct {
+	owner *[]ChatMessage
+	line  string
+}
+
 // ClearNotificationMsg is sent to clear the tool notification
 type ClearNotificationMsg struct{}
 
@@ -222,6 +246,11 @@ func NewModel(llm model.LLM, tools []tool.Tool, systemInstruction string, svc se
 	ta.ShowLineNumbers = false
 	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
 	ta.BlurredStyle.CursorLine = lipgloss.NewStyle()
+	// Enter submits (handled in Update); newlines are inserted with ctrl+j
+	ta.KeyMap.InsertNewline = key.NewBinding(
+		key.WithKeys("ctrl+j"),
+		key.WithHelp("ctrl+j", "newline"),
+	)
 
 	vp := viewport.New(80, 20)
 
@@ -350,6 +379,56 @@ func (m *Model) IsBusy() bool {
 	return m.loading
 }
 
+// ResumeCmd re-arms the spinner when the screen becomes current again while
+// a response is still being generated (spinner ticks are focus-only).
+func (m *Model) ResumeCmd() tea.Cmd {
+	if m.loading {
+		return m.spinner.Tick
+	}
+	return nil
+}
+
+// SetSystemInstruction replaces the system instruction for future turns.
+// Used when the user re-enters the chat for the same task with freshly
+// collected context.
+func (m *Model) SetSystemInstruction(instruction string) {
+	m.systemInstruction = instruction
+}
+
+// AppendNotice appends a muted one-line notice to the end of the transcript.
+func (m *Model) AppendNotice(content string) {
+	if m.msgs == nil || strings.TrimSpace(content) == "" {
+		return
+	}
+	*m.msgs = append(*m.msgs, ChatMessage{Role: "notice", Content: content})
+	if m.ready {
+		m.viewport.SetContent(m.renderMessages())
+		m.viewport.GotoBottom()
+	}
+}
+
+// submitInput sends the current textarea content to the LLM.
+func (m *Model) submitInput() (tea.Model, tea.Cmd) {
+	if m.loading {
+		return m, nil
+	}
+	input := m.textarea.Value()
+	if strings.TrimSpace(input) == "" {
+		return m, nil
+	}
+
+	*m.msgs = append(*m.msgs, ChatMessage{Role: "user", Content: input})
+	m.viewport.SetContent(m.renderMessages())
+	m.textarea.Reset()
+	m.viewport.GotoBottom()
+	m.loading = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancelGen = cancel
+
+	return m, tea.Batch(m.spinner.Tick, m.generateResponse(ctx, input))
+}
+
 // SetFocusMode sets the focus mode and updates UI state accordingly.
 func (m *Model) SetFocusMode(mode FocusMode) {
 	m.focusMode = mode
@@ -409,6 +488,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.Type {
 		case tea.KeyEsc:
+			// While generating, ESC cancels the in-flight response.
+			if m.loading && m.cancelGen != nil {
+				m.cancelGen()
+				return m, nil
+			}
 			// First ESC leaves the input; second ESC leaves the screen.
 			if m.focusMode == FocusInput {
 				m.SetFocusMode(FocusMessages)
@@ -418,6 +502,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m, common.NavigateCmd(common.NavigateBackMsg{})
+
+		case tea.KeyEnter:
+			if m.focusMode == FocusInput {
+				return m.submitInput()
+			}
 
 		case tea.KeyRunes:
 			// Handle 'y' for copy when in messages mode
@@ -476,21 +565,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case tea.KeyCtrlD:
-			if m.loading {
-				return m, nil
+			// Kept as an alias for Enter for muscle memory
+			if m.focusMode == FocusInput {
+				return m.submitInput()
 			}
-			input := m.textarea.Value()
-			if strings.TrimSpace(input) == "" {
-				return m, nil
-			}
-
-			*m.msgs = append(*m.msgs, ChatMessage{Role: "user", Content: input})
-			m.viewport.SetContent(m.renderMessages())
-			m.textarea.Reset()
-			m.viewport.GotoBottom()
-			m.loading = true
-
-			return m, tea.Batch(m.spinner.Tick, m.generateResponse(input))
 
 		case tea.KeyCtrlS:
 			// Handle Ctrl+S for sessions modal when not loading
@@ -506,7 +584,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.loading = false
 		m.toolNotification = ""
-		if msg.Err != nil {
+		m.cancelGen = nil
+		partialText := m.streamingText
+		m.streamingText = ""
+		if errors.Is(msg.Err, context.Canceled) {
+			// User cancelled: keep whatever streamed and say so.
+			if partialText != "" {
+				rendered := renderMarkdown(partialText, m.width-8)
+				*m.msgs = append(*m.msgs, ChatMessage{Role: "agent", Content: partialText, Rendered: rendered})
+			}
+			*m.msgs = append(*m.msgs, ChatMessage{Role: "notice", Content: "Generation cancelled"})
+		} else if msg.Err != nil {
 			*m.msgs = append(*m.msgs, ChatMessage{Role: "error", Content: fmt.Sprintf("%v", msg.Err)})
 		} else {
 			rendered := renderMarkdown(msg.Content, m.width-8)
@@ -538,6 +626,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.textarea.Focus()
 		m.focusMode = FocusInput
 		return m, textarea.Blink
+
+	case streamChunkMsg:
+		if msg.owner != m.msgs || !m.loading {
+			return m, nil
+		}
+		m.streamingText = msg.text
+		m.viewport.SetContent(m.renderMessages())
+		m.viewport.GotoBottom()
+		return m, nil
+
+	case toolRecordMsg:
+		if msg.owner != m.msgs {
+			return m, nil
+		}
+		*m.msgs = append(*m.msgs, ChatMessage{Role: "tool", Content: msg.line})
+		m.viewport.SetContent(m.renderMessages())
+		m.viewport.GotoBottom()
+		return m, nil
 
 	case ToolNotificationMsg:
 		if msg.owner != nil && msg.owner != m.msgs {
@@ -756,16 +862,23 @@ func (m Model) renderFooter() string {
 		return common.KeyStyle.Render(key) + " " + common.DescStyle.Render(desc)
 	}
 	var hints []string
-	if m.focusMode == FocusMessages {
+	switch {
+	case m.loading:
+		hints = []string{
+			hint("esc", "cancel"),
+			hint("↑↓", "scroll"),
+		}
+	case m.focusMode == FocusMessages:
 		hints = []string{
 			hint("↑↓", "navigate"),
 			hint("y", "copy"),
 			hint("tab", "type"),
 			hint("esc", escAction),
 		}
-	} else {
+	default:
 		hints = []string{
-			hint("ctrl+d", "send"),
+			hint("enter", "send"),
+			hint("ctrl+j", "newline"),
 			hint("ctrl+s", "sessions"),
 			hint("↑↓", "scroll"),
 			hint("tab", "navigate msgs"),
@@ -788,8 +901,9 @@ func (m Model) renderFooter() string {
 }
 
 func (m Model) renderMessages() string {
-	if m.msgs == nil || len(*m.msgs) == 0 {
-		return common.MutedStyle.Render("Welcome to Pumbaa Chat! 🐗\n\nType your message and press Ctrl+D to send.")
+	hasMsgs := m.msgs != nil && len(*m.msgs) > 0
+	if !hasMsgs && m.streamingText == "" {
+		return common.MutedStyle.Render("Welcome to Pumbaa Chat! 🐗\n\nType your message and press Enter to send (ctrl+j for a new line).")
 	}
 
 	var sb strings.Builder
@@ -803,50 +917,77 @@ func (m Model) renderMessages() string {
 		Background(common.SubtleColor).
 		Padding(0, 1)
 
-	for i, msg := range *m.msgs {
-		var roleStyle lipgloss.Style
-		var roleName string
-		contentStyle := messageStyle
+	if hasMsgs {
+		for i, msg := range *m.msgs {
+			isSelected := m.focusMode == FocusMessages && i == m.selectedMsg
 
-		switch msg.Role {
-		case "user":
-			roleStyle = userStyle
-			roleName = "You"
-		case "agent":
-			roleStyle = agentStyle
-			roleName = "Pumbaa"
-		case "info":
-			roleStyle = infoStyle
-			roleName = "Context"
-			contentStyle = infoMessageStyle
-		default:
-			roleStyle = errorStyle
-			roleName = "Error"
+			// Compact one-line roles: tool records and notices have no header
+			switch msg.Role {
+			case "tool":
+				line := common.MutedStyle.Render("🔧 " + msg.Content)
+				if isSelected {
+					line = selectedStyle.Render("▶ " + line)
+				}
+				sb.WriteString(line + "\n\n")
+				continue
+			case "notice":
+				line := common.MutedStyle.Italic(true).Render("· " + msg.Content)
+				if isSelected {
+					line = selectedStyle.Render("▶ " + line)
+				}
+				sb.WriteString(line + "\n\n")
+				continue
+			}
+
+			var roleStyle lipgloss.Style
+			var roleName string
+			contentStyle := messageStyle
+
+			switch msg.Role {
+			case "user":
+				roleStyle = userStyle
+				roleName = "You"
+			case "agent":
+				roleStyle = agentStyle
+				roleName = "Pumbaa"
+			case "info":
+				roleStyle = infoStyle
+				roleName = "Context"
+				contentStyle = infoMessageStyle
+			default:
+				roleStyle = errorStyle
+				roleName = "Error"
+			}
+
+			// Render role with selection indicator
+			if isSelected {
+				sb.WriteString(selectedStyle.Render("▶ "+roleStyle.Render(roleName)) + "\n")
+			} else {
+				sb.WriteString(roleStyle.Render(roleName) + "\n")
+			}
+
+			// Render content
+			var content string
+			if msg.Role == "agent" && msg.Rendered != "" {
+				content = msg.Rendered
+			} else {
+				content = contentStyle.Render(wrapText(msg.Content, maxWidth))
+			}
+
+			if isSelected {
+				sb.WriteString(selectedStyle.Render(content))
+			} else {
+				sb.WriteString(content)
+			}
+			sb.WriteString("\n\n")
 		}
+	}
 
-		// Highlight if selected
-		isSelected := m.focusMode == FocusMessages && i == m.selectedMsg
-
-		// Render role with selection indicator
-		if isSelected {
-			sb.WriteString(selectedStyle.Render("▶ "+roleStyle.Render(roleName)) + "\n")
-		} else {
-			sb.WriteString(roleStyle.Render(roleName) + "\n")
-		}
-
-		// Render content
-		var content string
-		if msg.Role == "agent" && msg.Rendered != "" {
-			content = msg.Rendered
-		} else {
-			content = contentStyle.Render(wrapText(msg.Content, maxWidth))
-		}
-
-		if isSelected {
-			sb.WriteString(selectedStyle.Render(content))
-		} else {
-			sb.WriteString(content)
-		}
+	// Live response being streamed: plain text with a cursor block; the
+	// final ResponseMsg replaces it with the markdown-rendered message.
+	if m.loading && m.streamingText != "" {
+		sb.WriteString(agentStyle.Render("Pumbaa") + "\n")
+		sb.WriteString(messageStyle.Render(wrapText(m.streamingText, maxWidth) + " ▌"))
 		sb.WriteString("\n\n")
 	}
 
@@ -967,10 +1108,8 @@ func formatTokenCount(count int) string {
 	return fmt.Sprintf("%d", count)
 }
 
-func (m Model) generateResponse(input string) tea.Cmd {
+func (m Model) generateResponse(ctx context.Context, input string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
-
 		userContent := &genai.Content{
 			Role: "user",
 			Parts: []*genai.Part{
@@ -993,6 +1132,10 @@ func (m Model) generateResponse(input string) tea.Cmd {
 		totalOutputTokens := 0
 
 		for currentTurn < maxTurns {
+			if ctx.Err() != nil {
+				return ResponseMsg{Err: ctx.Err(), owner: m.msgs}
+			}
+
 			req := &model.LLMRequest{
 				Contents: *m.history,
 				Config: &genai.GenerateContentConfig{
@@ -1008,13 +1151,23 @@ func (m Model) generateResponse(input string) tea.Cmd {
 				}
 			}
 
-			respSeq := m.llm.GenerateContent(ctx, req, false)
+			respSeq := m.llm.GenerateContent(ctx, req, true)
 
 			var lastResp *model.LLMResponse
+			var turnText strings.Builder
 
 			for r, e := range respSeq {
 				if e != nil {
 					return ResponseMsg{Err: e, owner: m.msgs}
+				}
+				if r.Partial {
+					// Forward the accumulated turn text so the UI renders
+					// the response as it streams.
+					turnText.WriteString(extractText(r.Content))
+					if m.program != nil {
+						m.program.Send(streamChunkMsg{owner: m.msgs, text: turnText.String()})
+					}
+					continue
 				}
 				lastResp = r
 			}
@@ -1066,7 +1219,15 @@ func (m Model) generateResponse(input string) tea.Cmd {
 						m.program.Send(ToolNotificationMsg{ToolName: tc.Name, Action: action, Params: otherParams, owner: m.msgs})
 					}
 
+					toolStart := time.Now()
 					result, err := m.executeTool(ctx, tc)
+					if m.program != nil {
+						// Persistent transcript record of what the agent did
+						m.program.Send(toolRecordMsg{
+							owner: m.msgs,
+							line:  formatToolRecord(tc.Name, action, otherParams, time.Since(toolStart), err),
+						})
+					}
 					if err != nil {
 						toolParts = append(toolParts, &genai.Part{
 							FunctionResponse: &genai.FunctionResponse{
@@ -1133,6 +1294,34 @@ func (m Model) generateResponse(input string) tea.Cmd {
 
 		return ResponseMsg{Content: summary.String(), owner: m.msgs}
 	}
+}
+
+// formatToolRecord builds the one-line transcript record of a tool call,
+// e.g. `pumbaa query (status=Failed) ✓ 0.8s`.
+func formatToolRecord(name, action string, params map[string]any, dur time.Duration, err error) string {
+	label := name
+	if action != "" {
+		label += " " + action
+	}
+
+	if len(params) > 0 {
+		keys := make([]string, 0, len(params))
+		for k := range params {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		pairs := make([]string, 0, len(keys))
+		for _, k := range keys {
+			pairs = append(pairs, fmt.Sprintf("%s=%v", k, params[k]))
+		}
+		label += " (" + strings.Join(pairs, ", ") + ")"
+	}
+
+	mark := "✓"
+	if err != nil {
+		mark = "✗"
+	}
+	return fmt.Sprintf("%s %s %.1fs", label, mark, dur.Seconds())
 }
 
 func getToolCalls(content *genai.Content) []*genai.FunctionCall {

--- a/internal/interfaces/tui/chat/model.go
+++ b/internal/interfaces/tui/chat/model.go
@@ -160,6 +160,11 @@ type ResponseMsg struct {
 	Err          error
 	InputTokens  int // Input tokens used in this response
 	OutputTokens int // Output tokens generated in this response
+
+	// owner identifies the conversation that produced this response (the
+	// model's msgs pointer is unique per instance), so an in-flight response
+	// from a previous chat can never be appended to a newer conversation.
+	owner *[]ChatMessage
 }
 
 // ToolNotificationMsg is sent when a tool is being called
@@ -167,6 +172,8 @@ type ToolNotificationMsg struct {
 	ToolName string
 	Action   string
 	Params   map[string]any // Additional parameters
+
+	owner *[]ChatMessage // See ResponseMsg.owner
 }
 
 // ClearNotificationMsg is sent to clear the tool notification
@@ -311,9 +318,31 @@ func (m *Model) AddInfoMessage(content string) {
 }
 
 // SetSession attaches a session created asynchronously after the screen
-// opened, so session creation never blocks the UI thread.
+// opened, so session creation never blocks the UI thread. Turns exchanged
+// while the session was still being created are persisted retroactively.
 func (m *Model) SetSession(sess session.Session) {
 	m.session = sess
+	if sess == nil || m.sessionService == nil || m.history == nil || len(*m.history) == 0 {
+		return
+	}
+	if m.loading {
+		// A generation is appending to history from its own goroutine;
+		// copying it here would race. That in-flight turn stays unpersisted.
+		return
+	}
+
+	backlog := make([]*genai.Content, len(*m.history))
+	copy(backlog, *m.history)
+	svc := m.sessionService
+	go func() {
+		ctx := context.Background()
+		for _, content := range backlog {
+			ev := session.NewEvent("")
+			ev.Content = content
+			ev.Author = content.Role
+			svc.AppendEvent(ctx, sess, ev)
+		}
+	}()
 }
 
 // IsBusy reports whether a response is currently being generated.
@@ -471,6 +500,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case ResponseMsg:
+		if msg.owner != nil && msg.owner != m.msgs {
+			// Response from a previous conversation; drop it.
+			return m, nil
+		}
 		m.loading = false
 		m.toolNotification = ""
 		if msg.Err != nil {
@@ -507,6 +540,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, textarea.Blink
 
 	case ToolNotificationMsg:
+		if msg.owner != nil && msg.owner != m.msgs {
+			return m, nil
+		}
 		if msg.Action != "" {
 			// Format params if present
 			paramsStr := ""
@@ -978,13 +1014,13 @@ func (m Model) generateResponse(input string) tea.Cmd {
 
 			for r, e := range respSeq {
 				if e != nil {
-					return ResponseMsg{Err: e}
+					return ResponseMsg{Err: e, owner: m.msgs}
 				}
 				lastResp = r
 			}
 
 			if lastResp == nil || lastResp.Content == nil {
-				return ResponseMsg{Err: fmt.Errorf("empty response from model")}
+				return ResponseMsg{Err: fmt.Errorf("empty response from model"), owner: m.msgs}
 			}
 
 			// Accumulate token usage from this response
@@ -1027,7 +1063,7 @@ func (m Model) generateResponse(input string) tea.Cmd {
 
 					// Send notification to UI about tool being called
 					if m.program != nil {
-						m.program.Send(ToolNotificationMsg{ToolName: tc.Name, Action: action, Params: otherParams})
+						m.program.Send(ToolNotificationMsg{ToolName: tc.Name, Action: action, Params: otherParams, owner: m.msgs})
 					}
 
 					result, err := m.executeTool(ctx, tc)
@@ -1074,7 +1110,7 @@ func (m Model) generateResponse(input string) tea.Cmd {
 					text += part.Text
 				}
 			}
-			return ResponseMsg{Content: text, InputTokens: totalInputTokens, OutputTokens: totalOutputTokens}
+			return ResponseMsg{Content: text, InputTokens: totalInputTokens, OutputTokens: totalOutputTokens, owner: m.msgs}
 		}
 
 		// Max turns reached
@@ -1095,7 +1131,7 @@ func (m Model) generateResponse(input string) tea.Cmd {
 
 		summary.WriteString("\nIf you need more information, please ask a more specific question or ask me to continue from where I left off.")
 
-		return ResponseMsg{Content: summary.String()}
+		return ResponseMsg{Content: summary.String(), owner: m.msgs}
 	}
 }
 

--- a/internal/interfaces/tui/chat/model.go
+++ b/internal/interfaces/tui/chat/model.go
@@ -145,10 +145,8 @@ type Model struct {
 	sessionsSearching   bool
 	sessionsSearchInput textinput.Model
 
-	// Navigation state
-	wantsToGoBack bool
-	wantsToQuit   bool
-	standalone    bool // True when running directly from CLI (pumbaa chat), not embedded in TUI
+	// standalone is true when running directly from CLI (pumbaa chat), not embedded in TUI
+	standalone bool
 }
 
 type ChatMessage struct {
@@ -312,30 +310,15 @@ func (m *Model) AddInfoMessage(content string) {
 	*m.msgs = append([]ChatMessage{msg}, (*m.msgs)...)
 }
 
-// ShouldGoBack returns true if the user wants to navigate back.
-func (m *Model) ShouldGoBack() bool {
-	return m.wantsToGoBack
+// SetSession attaches a session created asynchronously after the screen
+// opened, so session creation never blocks the UI thread.
+func (m *Model) SetSession(sess session.Session) {
+	m.session = sess
 }
 
-// ClearNavigation clears the navigation state.
-func (m *Model) ClearNavigation() {
-	m.wantsToGoBack = false
-	m.wantsToQuit = false
-}
-
-// ShouldQuit returns true if the user wants to quit the program.
-func (m *Model) ShouldQuit() bool {
-	return m.wantsToQuit
-}
-
-// HasActiveModal returns true if there's an active modal being displayed.
-func (m *Model) HasActiveModal() bool {
-	return m.activeModal != ModalNone
-}
-
-// GetFocusMode returns the current focus mode.
-func (m *Model) GetFocusMode() FocusMode {
-	return m.focusMode
+// IsBusy reports whether a response is currently being generated.
+func (m *Model) IsBusy() bool {
+	return m.loading
 }
 
 // SetFocusMode sets the focus mode and updates UI state accordingly.
@@ -397,13 +380,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.Type {
 		case tea.KeyEsc:
-			// In standalone mode, ESC in FocusMessages triggers back
-			// In embedded mode, AppModel handles this
-			if m.standalone && m.focusMode == FocusMessages {
-				m.wantsToGoBack = true
+			// First ESC leaves the input; second ESC leaves the screen.
+			if m.focusMode == FocusInput {
+				m.SetFocusMode(FocusMessages)
+				return m, nil
+			}
+			if m.standalone {
 				return m, tea.Quit
 			}
-			// ESC is now handled by AppModel for navigation
+			return m, common.NavigateCmd(common.NavigateBackMsg{})
 
 		case tea.KeyRunes:
 			// Handle 'y' for copy when in messages mode
@@ -748,7 +733,7 @@ func (m Model) renderFooter() string {
 			hint("ctrl+s", "sessions"),
 			hint("↑↓", "scroll"),
 			hint("tab", "navigate msgs"),
-			hint("esc", escAction),
+			hint("esc", "messages"),
 		}
 	}
 

--- a/internal/interfaces/tui/chat/model.go
+++ b/internal/interfaces/tui/chat/model.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/adk/tool"
 	"google.golang.org/genai"
 
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools"
 	infraSession "github.com/lmtani/pumbaa/internal/infrastructure/session"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
 )
@@ -143,6 +144,10 @@ type Model struct {
 	// resumableID points at a previous session for the same task context,
 	// offered for resume via ctrl+r.
 	resumableID string
+
+	// msgOffsets holds the rendered line offset of each message, refreshed
+	// by renderMessages, so selection scrolling targets real positions.
+	msgOffsets []int
 
 	// Token usage tracking
 	inputTokens  int // Accumulated input tokens for the session
@@ -596,12 +601,45 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case tea.KeyRunes:
-			// Handle 'y' for copy when in messages mode
-			if len(msg.Runes) > 0 && msg.Runes[0] == 'y' && m.focusMode == FocusMessages {
-				if m.msgs != nil && m.selectedMsg >= 0 && m.selectedMsg < len(*m.msgs) {
-					content := (*m.msgs)[m.selectedMsg].Content
-					return m, copyToClipboard(content)
+			// Message-navigation keys, only when browsing messages
+			if m.focusMode == FocusMessages && len(msg.Runes) > 0 && m.msgs != nil && len(*m.msgs) > 0 {
+				switch msg.Runes[0] {
+				case 'y': // copy selected message
+					if m.selectedMsg >= 0 && m.selectedMsg < len(*m.msgs) {
+						content := (*m.msgs)[m.selectedMsg].Content
+						return m, copyToClipboard(content)
+					}
+				case 'g': // first message
+					m.selectedMsg = 0
+					m.viewport.SetContent(m.renderMessages())
+					m.viewport.GotoTop()
+					return m, nil
+				case 'G': // last message
+					m.selectedMsg = len(*m.msgs) - 1
+					m.viewport.SetContent(m.renderMessages())
+					m.viewport.GotoBottom()
+					return m, nil
 				}
+			}
+
+		case tea.KeyPgUp:
+			m.viewport.PageUp()
+			return m, nil
+
+		case tea.KeyPgDown:
+			m.viewport.PageDown()
+			return m, nil
+
+		case tea.KeyHome:
+			if m.focusMode == FocusMessages {
+				m.viewport.GotoTop()
+				return m, nil
+			}
+
+		case tea.KeyEnd:
+			if m.focusMode == FocusMessages {
+				m.viewport.GotoBottom()
+				return m, nil
 			}
 
 		case tea.KeyTab:
@@ -633,7 +671,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			} else if m.focusMode == FocusInput {
 				// Scroll viewport up when focus is on input
-				m.viewport.LineUp(3)
+				m.viewport.ScrollUp(3)
 				return m, nil
 			}
 
@@ -647,7 +685,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			} else if m.focusMode == FocusInput {
 				// Scroll viewport down when focus is on input
-				m.viewport.LineDown(3)
+				m.viewport.ScrollDown(3)
 				return m, nil
 			}
 
@@ -955,28 +993,20 @@ func (m Model) renderInput() string {
 	return inputBox
 }
 
-// scrollToSelectedMsg scrolls the viewport to center the selected message
+// scrollToSelectedMsg scrolls the viewport so the selected message is
+// visible, using the real rendered line offsets tracked by renderMessages.
 func (m *Model) scrollToSelectedMsg() {
-	if m.msgs == nil || m.selectedMsg < 0 || m.selectedMsg >= len(*m.msgs) {
+	if m.msgs == nil || m.selectedMsg < 0 || m.selectedMsg >= len(*m.msgs) || m.selectedMsg >= len(m.msgOffsets) {
 		return
 	}
 
-	// Calculate approximate position based on message index
-	// Each message is roughly: role line (1) + content lines + spacing (2)
-	// We estimate ~6 lines per message on average for a good approximation
-	linesPerMsg := 6
-	targetLine := m.selectedMsg * linesPerMsg
-
-	// Center the message in the viewport
-	viewportHeight := m.viewport.Height
-	centeredOffset := targetLine - (viewportHeight / 2)
-
-	// Clamp to valid range
-	if centeredOffset < 0 {
-		centeredOffset = 0
+	// Place the message a third from the top: it reads naturally and leaves
+	// room for the following context.
+	offset := m.msgOffsets[m.selectedMsg] - m.viewport.Height/3
+	if offset < 0 {
+		offset = 0
 	}
-
-	m.viewport.SetYOffset(centeredOffset)
+	m.viewport.SetYOffset(offset)
 }
 
 func (m Model) renderFooter() string {
@@ -999,6 +1029,8 @@ func (m Model) renderFooter() string {
 	case m.focusMode == FocusMessages:
 		hints = []string{
 			hint("↑↓", "navigate"),
+			hint("pgup/pgdn", "page"),
+			hint("g/G", "first/last"),
 			hint("y", "copy"),
 			hint("tab", "type"),
 			hint("esc", escAction),
@@ -1033,9 +1065,10 @@ func (m Model) renderFooter() string {
 		Render(prefix + help)
 }
 
-func (m Model) renderMessages() string {
+func (m *Model) renderMessages() string {
 	hasMsgs := m.msgs != nil && len(*m.msgs) > 0
 	if !hasMsgs && m.streamingText == "" {
+		m.msgOffsets = nil
 		return common.MutedStyle.Render("Welcome to Pumbaa Chat! 🐗\n\nType your message and press Enter to send (ctrl+j for a new line).")
 	}
 
@@ -1045,76 +1078,19 @@ func (m Model) renderMessages() string {
 		maxWidth = 80
 	}
 
-	// Style for selected message
-	selectedStyle := lipgloss.NewStyle().
-		Background(common.SubtleColor).
-		Padding(0, 1)
+	// Track each message's rendered line offset for selection scrolling
+	lineCount := 0
+	offsets := make([]int, 0, 16)
 
 	if hasMsgs {
 		for i, msg := range *m.msgs {
-			isSelected := m.focusMode == FocusMessages && i == m.selectedMsg
-
-			// Compact one-line roles: tool records and notices have no header
-			switch msg.Role {
-			case "tool":
-				line := common.MutedStyle.Render("🔧 " + msg.Content)
-				if isSelected {
-					line = selectedStyle.Render("▶ " + line)
-				}
-				sb.WriteString(line + "\n\n")
-				continue
-			case "notice":
-				line := common.MutedStyle.Italic(true).Render("· " + msg.Content)
-				if isSelected {
-					line = selectedStyle.Render("▶ " + line)
-				}
-				sb.WriteString(line + "\n\n")
-				continue
-			}
-
-			var roleStyle lipgloss.Style
-			var roleName string
-			contentStyle := messageStyle
-
-			switch msg.Role {
-			case "user":
-				roleStyle = userStyle
-				roleName = "You"
-			case "agent":
-				roleStyle = agentStyle
-				roleName = "Pumbaa"
-			case "info":
-				roleStyle = infoStyle
-				roleName = "Context"
-				contentStyle = infoMessageStyle
-			default:
-				roleStyle = errorStyle
-				roleName = "Error"
-			}
-
-			// Render role with selection indicator
-			if isSelected {
-				sb.WriteString(selectedStyle.Render("▶ "+roleStyle.Render(roleName)) + "\n")
-			} else {
-				sb.WriteString(roleStyle.Render(roleName) + "\n")
-			}
-
-			// Render content
-			var content string
-			if msg.Role == "agent" && msg.Rendered != "" {
-				content = msg.Rendered
-			} else {
-				content = contentStyle.Render(wrapText(msg.Content, maxWidth))
-			}
-
-			if isSelected {
-				sb.WriteString(selectedStyle.Render(content))
-			} else {
-				sb.WriteString(content)
-			}
-			sb.WriteString("\n\n")
+			block := m.renderMessageBlock(i, msg, maxWidth)
+			offsets = append(offsets, lineCount)
+			sb.WriteString(block)
+			lineCount += strings.Count(block, "\n")
 		}
 	}
+	m.msgOffsets = offsets
 
 	// Live response being streamed: plain text with a cursor block; the
 	// final ResponseMsg replaces it with the markdown-rendered message.
@@ -1123,6 +1099,77 @@ func (m Model) renderMessages() string {
 		sb.WriteString(messageStyle.Render(wrapText(m.streamingText, maxWidth) + " ▌"))
 		sb.WriteString("\n\n")
 	}
+
+	return sb.String()
+}
+
+// renderMessageBlock renders a single transcript message, including its
+// trailing spacing, so renderMessages can measure real line offsets.
+func (m *Model) renderMessageBlock(i int, msg ChatMessage, maxWidth int) string {
+	isSelected := m.focusMode == FocusMessages && i == m.selectedMsg
+	selectedStyle := lipgloss.NewStyle().
+		Background(common.SubtleColor).
+		Padding(0, 1)
+
+	// Compact one-line roles: tool records and notices have no header
+	switch msg.Role {
+	case "tool":
+		line := common.MutedStyle.Render("🔧 " + msg.Content)
+		if isSelected {
+			line = selectedStyle.Render("▶ " + line)
+		}
+		return line + "\n\n"
+	case "notice":
+		line := common.MutedStyle.Italic(true).Render("· " + msg.Content)
+		if isSelected {
+			line = selectedStyle.Render("▶ " + line)
+		}
+		return line + "\n\n"
+	}
+
+	var roleStyle lipgloss.Style
+	var roleName string
+	contentStyle := messageStyle
+
+	switch msg.Role {
+	case "user":
+		roleStyle = userStyle
+		roleName = "You"
+	case "agent":
+		roleStyle = agentStyle
+		roleName = "Pumbaa"
+	case "info":
+		roleStyle = infoStyle
+		roleName = "Context"
+		contentStyle = infoMessageStyle
+	default:
+		roleStyle = errorStyle
+		roleName = "Error"
+	}
+
+	var sb strings.Builder
+
+	// Render role with selection indicator
+	if isSelected {
+		sb.WriteString(selectedStyle.Render("▶ "+roleStyle.Render(roleName)) + "\n")
+	} else {
+		sb.WriteString(roleStyle.Render(roleName) + "\n")
+	}
+
+	// Render content
+	var content string
+	if msg.Role == "agent" && msg.Rendered != "" {
+		content = msg.Rendered
+	} else {
+		content = contentStyle.Render(wrapText(msg.Content, maxWidth))
+	}
+
+	if isSelected {
+		sb.WriteString(selectedStyle.Render(content))
+	} else {
+		sb.WriteString(content)
+	}
+	sb.WriteString("\n\n")
 
 	return sb.String()
 }
@@ -1372,7 +1419,7 @@ func (m Model) generateResponse(ctx context.Context, input string) tea.Cmd {
 						// Persistent transcript record of what the agent did
 						m.program.Send(toolRecordMsg{
 							owner: m.msgs,
-							line:  formatToolRecord(tc.Name, action, otherParams, time.Since(toolStart), err),
+							line:  formatToolRecord(tc.Name, action, otherParams, time.Since(toolStart), toolFailure(result, err)),
 						})
 					}
 					if err != nil {
@@ -1443,9 +1490,28 @@ func (m Model) generateResponse(ctx context.Context, input string) tea.Cmd {
 	}
 }
 
+// toolFailure extracts a short failure description from a tool execution:
+// either a transport error or a handler-level error output (success=false).
+// Returns "" when the call succeeded.
+func toolFailure(result map[string]any, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	if result != nil {
+		if success, ok := result["success"].(bool); ok && !success {
+			if msg, ok := result["error"].(string); ok && msg != "" {
+				return msg
+			}
+			return "failed"
+		}
+	}
+	return ""
+}
+
 // formatToolRecord builds the one-line transcript record of a tool call,
-// e.g. `pumbaa query (status=Failed) ✓ 0.8s`.
-func formatToolRecord(name, action string, params map[string]any, dur time.Duration, err error) string {
+// e.g. `pumbaa query (status=Failed) ✓ 0.8s`. Failures include a short
+// reason so the transcript explains itself.
+func formatToolRecord(name, action string, params map[string]any, dur time.Duration, failure string) string {
 	label := name
 	if action != "" {
 		label += " " + action
@@ -1464,11 +1530,10 @@ func formatToolRecord(name, action string, params map[string]any, dur time.Durat
 		label += " (" + strings.Join(pairs, ", ") + ")"
 	}
 
-	mark := "✓"
-	if err != nil {
-		mark = "✗"
+	if failure != "" {
+		return fmt.Sprintf("%s ✗ %.1fs — %s", label, dur.Seconds(), common.Truncate(failure, 80))
 	}
-	return fmt.Sprintf("%s %s %.1fs", label, mark, dur.Seconds())
+	return fmt.Sprintf("%s ✓ %.1fs", label, dur.Seconds())
 }
 
 func getToolCalls(content *genai.Content) []*genai.FunctionCall {
@@ -1486,7 +1551,9 @@ func (m Model) executeTool(ctx context.Context, fc *genai.FunctionCall) (map[str
 		if td, ok := t.(toolWithDefinition); ok {
 			def := td.Declaration()
 			if def.Name == fc.Name {
-				return td.Run(nil, fc.Args)
+				// functiontool.Run dereferences the tool context (ADK v1.0.0
+				// panics on nil), so pass the minimal no-op context.
+				return td.Run(tools.NoopToolContext(), fc.Args)
 			}
 		}
 	}

--- a/internal/interfaces/tui/chat/model.go
+++ b/internal/interfaces/tui/chat/model.go
@@ -135,6 +135,15 @@ type Model struct {
 	// cancelGen aborts the in-flight generation (ESC while loading).
 	cancelGen context.CancelFunc
 
+	// Lazy session lifecycle: the session is created on the first message so
+	// abandoned chats never leave empty rows behind.
+	sessionCreating bool
+	pendingFlush    bool // persist history once the in-flight generation ends
+
+	// resumableID points at a previous session for the same task context,
+	// offered for resume via ctrl+r.
+	resumableID string
+
 	// Token usage tracking
 	inputTokens  int // Accumulated input tokens for the session
 	outputTokens int // Accumulated output tokens for the session
@@ -198,6 +207,19 @@ type streamChunkMsg struct {
 type toolRecordMsg struct {
 	owner *[]ChatMessage
 	line  string
+}
+
+// sessionCreatedMsg carries the result of the lazy session creation.
+type sessionCreatedMsg struct {
+	owner   *[]ChatMessage
+	session session.Session
+	err     error
+}
+
+// resumableFoundMsg reports a previous session for the same task context.
+type resumableFoundMsg struct {
+	owner *[]ChatMessage
+	info  infraSession.SessionInfo
 }
 
 // ClearNotificationMsg is sent to clear the tool notification
@@ -351,18 +373,30 @@ func (m *Model) AddInfoMessage(content string) {
 // while the session was still being created are persisted retroactively.
 func (m *Model) SetSession(sess session.Session) {
 	m.session = sess
-	if sess == nil || m.sessionService == nil || m.history == nil || len(*m.history) == 0 {
+	if sess == nil {
 		return
 	}
 	if m.loading {
 		// A generation is appending to history from its own goroutine;
-		// copying it here would race. That in-flight turn stays unpersisted.
+		// copying it here would race. Flush once the response lands.
+		m.pendingFlush = true
+		return
+	}
+	m.flushHistory()
+}
+
+// flushHistory persists the whole in-memory history to the session. Used
+// when the session attaches after turns already happened (lazy creation).
+func (m *Model) flushHistory() {
+	m.pendingFlush = false
+	if m.session == nil || m.sessionService == nil || m.history == nil || len(*m.history) == 0 {
 		return
 	}
 
 	backlog := make([]*genai.Content, len(*m.history))
 	copy(backlog, *m.history)
 	svc := m.sessionService
+	sess := m.session
 	go func() {
 		ctx := context.Background()
 		for _, content := range backlog {
@@ -426,7 +460,15 @@ func (m *Model) submitInput() (tea.Model, tea.Cmd) {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancelGen = cancel
 
-	return m, tea.Batch(m.spinner.Tick, m.generateResponse(ctx, input))
+	cmds := []tea.Cmd{m.spinner.Tick, m.generateResponse(ctx, input)}
+
+	// Lazy session creation: the first message brings the session to life
+	if m.session == nil && m.sessionService != nil && !m.sessionCreating {
+		m.sessionCreating = true
+		cmds = append(cmds, m.createSessionCmd())
+	}
+
+	return m, tea.Batch(cmds...)
 }
 
 // SetFocusMode sets the focus mode and updates UI state accordingly.
@@ -446,7 +488,52 @@ func (m *Model) SetFocusMode(mode FocusMode) {
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(textarea.Blink, tea.EnterAltScreen)
+	return tea.Batch(textarea.Blink, tea.EnterAltScreen, m.findResumableCmd())
+}
+
+// findResumableCmd looks up a previous session for the same task context, so
+// the user can resume it with ctrl+r instead of starting over.
+func (m *Model) findResumableCmd() tea.Cmd {
+	if m.session != nil || m.contextLabel == "" {
+		return nil
+	}
+	svc, ok := m.sessionService.(*infraSession.SQLiteService)
+	if !ok {
+		return nil
+	}
+	label := m.contextLabel
+	owner := m.msgs
+	return func() tea.Msg {
+		info, err := svc.FindLatestByContextLabel(context.Background(), infraSession.DefaultAppName, infraSession.DefaultUserID, label)
+		if err != nil || info == nil {
+			return nil
+		}
+		return resumableFoundMsg{owner: owner, info: *info}
+	}
+}
+
+// createSessionCmd creates the persistent session on first use and tags it
+// with the task context for later resume-by-task lookups.
+func (m *Model) createSessionCmd() tea.Cmd {
+	svc := m.sessionService
+	label := m.contextLabel
+	owner := m.msgs
+	return func() tea.Msg {
+		ctx := context.Background()
+		resp, err := svc.Create(ctx, &session.CreateRequest{
+			AppName: infraSession.DefaultAppName,
+			UserID:  infraSession.DefaultUserID,
+		})
+		if err != nil {
+			return sessionCreatedMsg{owner: owner, err: err}
+		}
+		if label != "" {
+			if sqliteSvc, ok := svc.(*infraSession.SQLiteService); ok {
+				_ = sqliteSvc.SetContextLabel(ctx, resp.Session.ID(), label)
+			}
+		}
+		return sessionCreatedMsg{owner: owner, session: resp.Session}
+	}
 }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -575,6 +662,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !m.loading {
 				return m.openSessionsModal()
 			}
+
+		case tea.KeyCtrlR:
+			// Resume the previous conversation for this task context
+			if m.resumableID != "" && !m.loading {
+				resumeID := m.resumableID
+				m.resumableID = ""
+				return m.switchToSession(resumeID)
+			}
 		}
 
 	case ResponseMsg:
@@ -585,6 +680,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		m.toolNotification = ""
 		m.cancelGen = nil
+		if m.pendingFlush {
+			// Session attached mid-generation; history is stable now
+			m.flushHistory()
+		}
 		partialText := m.streamingText
 		m.streamingText = ""
 		if errors.Is(msg.Err, context.Canceled) {
@@ -626,6 +725,34 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.textarea.Focus()
 		m.focusMode = FocusInput
 		return m, textarea.Blink
+
+	case sessionCreatedMsg:
+		if msg.owner != m.msgs {
+			return m, nil
+		}
+		m.sessionCreating = false
+		if msg.err != nil {
+			m.AppendNotice("Session persistence unavailable: " + msg.err.Error())
+			return m, nil
+		}
+		m.resumableID = "" // this conversation now has its own session
+		m.SetSession(msg.session)
+		return m, nil
+
+	case resumableFoundMsg:
+		if msg.owner != m.msgs || m.session != nil {
+			return m, nil
+		}
+		m.resumableID = msg.info.ID
+		desc := msg.info.Summary
+		if desc == "" {
+			desc = msg.info.ContextLabel
+		}
+		m.AppendNotice(fmt.Sprintf(
+			"Previous conversation for this task: %s (%d events, %s) — press ctrl+r to resume",
+			common.Truncate(desc, 50), msg.info.EventCount, formatAge(time.Since(msg.info.UpdatedAt)),
+		))
+		return m, nil
 
 	case streamChunkMsg:
 		if msg.owner != m.msgs || !m.loading {
@@ -699,6 +826,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionSwitchedMsg:
 		m.activeModal = ModalNone
 		m.sessionsLoading = false
+		m.resumableID = ""
 		m.session = msg.session
 		m.history = &msg.history
 		// Rebuild msgs from history
@@ -879,11 +1007,16 @@ func (m Model) renderFooter() string {
 		hints = []string{
 			hint("enter", "send"),
 			hint("ctrl+j", "newline"),
+		}
+		if m.resumableID != "" {
+			hints = append(hints, hint("ctrl+r", "resume previous"))
+		}
+		hints = append(hints,
 			hint("ctrl+s", "sessions"),
 			hint("↑↓", "scroll"),
 			hint("tab", "navigate msgs"),
 			hint("esc", "messages"),
-		}
+		)
 	}
 
 	// Show status message if present
@@ -1095,6 +1228,20 @@ func wrapText(text string, width int) string {
 	}
 
 	return result.String()
+}
+
+// formatAge renders a duration as a compact age, e.g. "2d ago".
+func formatAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
 }
 
 // formatTokenCount formats a token count in a human-readable format (e.g., 1.2K, 3.4M)

--- a/internal/interfaces/tui/common/nav.go
+++ b/internal/interfaces/tui/common/nav.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
+)
+
+// Navigation messages shared by all TUI screens.
+//
+// Screens emit these messages through commands (see NavigateCmd); the root
+// AppModel is the only handler. This keeps navigation unidirectional: screens
+// never know about each other, and the app model never inspects screen
+// internals to decide where to go.
+
+// NavigateToDebugMsg requests navigation to the debug screen for a workflow.
+type NavigateToDebugMsg struct {
+	Workflow *workflow.Workflow
+}
+
+// NavigateToChatMsg requests navigation to the chat screen.
+type NavigateToChatMsg struct {
+	SystemInstruction string
+	ContextSummary    string
+	ContextLabel      string // Shown as a badge in the chat header (e.g. "wf ▸ task")
+}
+
+// NavigateBackMsg asks the root model to leave the current screen. A screen
+// sends it only when it has nothing left to close itself (no modal, search,
+// or alternate view mode); at the root screen it triggers the quit flow.
+type NavigateBackMsg struct{}
+
+// NavigateCmd wraps a navigation message in a command.
+func NavigateCmd(msg tea.Msg) tea.Cmd {
+	return func() tea.Msg { return msg }
+}

--- a/internal/interfaces/tui/dashboard/diff.go
+++ b/internal/interfaces/tui/dashboard/diff.go
@@ -1,0 +1,275 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	workflowapp "github.com/lmtani/pumbaa/internal/application/workflow"
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
+	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
+)
+
+// handleCompareKey implements the two-step compare flow: the first press on a
+// workflow marks it as the base; the second press on a different workflow runs
+// the comparison; pressing it again on the base clears the mark.
+func (m *Model) handleCompareKey() tea.Cmd {
+	if m.compareUC == nil {
+		m.setStatusMessage("Compare not available")
+		return getClearStatusCmd()
+	}
+	if len(m.workflows) == 0 || m.cursor >= len(m.workflows) {
+		return nil
+	}
+	selected := m.workflows[m.cursor]
+
+	// No base yet: mark this one.
+	if m.compareBaseID == "" {
+		m.compareBaseID = selected.ID
+		m.compareBaseName = selected.Name
+		m.setStatusMessage("Marked base: " + truncateID(selected.ID) + " — select another and press c to compare")
+		return getClearStatusCmd()
+	}
+
+	// Same workflow: unmark.
+	if m.compareBaseID == selected.ID {
+		m.compareBaseID = ""
+		m.compareBaseName = ""
+		m.setStatusMessage("Compare base cleared")
+		return getClearStatusCmd()
+	}
+
+	// Second selection: run the comparison.
+	m.showDiff = true
+	m.diffLoading = true
+	m.diffError = ""
+	m.diffResult = nil
+	baseID := m.compareBaseID
+	otherID := selected.ID
+	return tea.Batch(m.spinner.Tick, m.runCompare(baseID, otherID))
+}
+
+// runCompare fetches and diffs the two runs off the UI thread.
+func (m *Model) runCompare(baseID, otherID string) tea.Cmd {
+	uc := m.compareUC
+	return func() tea.Msg {
+		diff, err := uc.Execute(context.Background(), workflowapp.CompareInput{
+			WorkflowIDA:  baseID,
+			WorkflowIDB:  otherID,
+			ResolveCache: true,
+		})
+		if err != nil {
+			return diffErrorMsg{err: err}
+		}
+		return diffLoadedMsg{diff: diff}
+	}
+}
+
+// handleDiffModalKeys handles input while the diff modal is open.
+func (m Model) handleDiffModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "c":
+		m.showDiff = false
+		m.diffResult = nil
+		m.diffError = ""
+		// Keep the base marked so the user can compare against another run.
+		return m, nil
+	case "up", "k":
+		m.diffViewport.ScrollUp(1)
+	case "down", "j":
+		m.diffViewport.ScrollDown(1)
+	case "pgup":
+		m.diffViewport.PageUp()
+	case "pgdown":
+		m.diffViewport.PageDown()
+	case "g", "home":
+		m.diffViewport.GotoTop()
+	case "G", "end":
+		m.diffViewport.GotoBottom()
+	}
+	return m, nil
+}
+
+// setDiffContent populates the diff viewport once the comparison completes.
+func (m *Model) setDiffContent() {
+	width := minInt(m.width-8, 110)
+	if width < 40 {
+		width = maxInt(20, m.width-4)
+	}
+	m.diffViewport = viewport.New(width-4, maxInt(6, m.height-10))
+	m.diffViewport.SetContent(renderDiffBody(m.diffResult, width-6))
+}
+
+// renderDiffModal renders the comparison result (or its loading/error state).
+func (m Model) renderDiffModal() string {
+	width := minInt(m.width-8, 110)
+	if width < 40 {
+		width = maxInt(20, m.width-4)
+	}
+
+	title := common.TitleStyle.Render("Workflow Comparison")
+
+	var body, footer string
+	switch {
+	case m.diffLoading:
+		body = m.spinner.View() + " " + common.MutedStyle.Render("Fetching and comparing both runs...")
+		footer = common.MutedStyle.Render("esc cancel")
+	case m.diffError != "":
+		body = common.ErrorStyle.Render("Comparison failed:") + "\n\n" +
+			lipgloss.NewStyle().Foreground(common.ErrorSoftColor).Width(width-6).Render(m.diffError)
+		footer = common.MutedStyle.Render("esc close")
+	default:
+		body = m.diffViewport.View()
+		footer = common.MutedStyle.Render("↑↓ scroll · PgUp/PgDn page · esc close")
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, title, "", body, "", footer)
+	modal := common.ModalStyle.Width(width).Render(content)
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modal,
+		lipgloss.WithWhitespaceChars(" "))
+}
+
+// renderDiffBody renders a RunDiff as styled text (mirrors the CLI presenter).
+func renderDiffBody(d *workflow.RunDiff, width int) string {
+	if d == nil {
+		return common.MutedStyle.Render("No comparison available")
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(common.LabelStyle.Render("A: ") + labelOrDash(d.NameA) + " " +
+		common.MutedStyle.Render(truncateID(d.IDA)) + " " + statusText(string(d.StatusA)) + "\n")
+	sb.WriteString(common.LabelStyle.Render("B: ") + labelOrDash(d.NameB) + " " +
+		common.MutedStyle.Render(truncateID(d.IDB)) + " " + statusText(string(d.StatusB)) + "\n")
+
+	if d.NameMismatch {
+		sb.WriteString(warnText("⚠ Workflow names differ — comparing runs of different workflows") + "\n")
+	}
+	if !d.HasDifferences() {
+		sb.WriteString("\n" + common.SuccessStyle.Render("✓ No differences found") + "\n")
+		return sb.String()
+	}
+
+	sb.WriteString(diffKeySection("Inputs", d.Inputs, width))
+	sb.WriteString(diffKeySection("Options", d.Options, width))
+
+	// Source
+	sb.WriteString("\n" + common.TitleStyle.Render("Source") + "\n")
+	if d.SourceChanged {
+		sb.WriteString("  " + yellow("~") + fmt.Sprintf(" WDL source changed (%d → %d lines)\n", d.SourceLinesA, d.SourceLinesB))
+	} else {
+		sb.WriteString("  " + common.MutedStyle.Render("unchanged") + "\n")
+	}
+
+	// Tasks
+	sb.WriteString("\n" + common.TitleStyle.Render(fmt.Sprintf("Tasks (%d of %d changed)", len(d.Tasks), d.TotalTasks)) + "\n")
+	for _, td := range d.Tasks {
+		sb.WriteString(diffTaskLines(td))
+	}
+
+	return sb.String()
+}
+
+func diffKeySection(title string, diffs []workflow.KeyDiff, width int) string {
+	var sb strings.Builder
+	if len(diffs) == 0 {
+		sb.WriteString("\n" + common.TitleStyle.Render(title+" (no changes)") + "\n")
+		return sb.String()
+	}
+	sb.WriteString("\n" + common.TitleStyle.Render(fmt.Sprintf("%s (%d changed)", title, len(diffs))) + "\n")
+	for _, kd := range diffs {
+		switch kd.Kind {
+		case workflow.ChangeAdded:
+			sb.WriteString("  " + green("+") + " " + kd.Key + "  " + valuePreview(kd.ValueB, width) + "\n")
+		case workflow.ChangeRemoved:
+			sb.WriteString("  " + red("-") + " " + kd.Key + "  " + valuePreview(kd.ValueA, width) + "\n")
+		default:
+			sb.WriteString("  " + yellow("~") + " " + kd.Key + "  " +
+				valuePreview(kd.ValueA, width) + " → " + valuePreview(kd.ValueB, width) + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func diffTaskLines(td workflow.TaskDiff) string {
+	var sb strings.Builder
+	switch td.Kind {
+	case workflow.ChangeAdded:
+		sb.WriteString("  " + green("+") + " " + td.Name + "  " + statusText(td.StatusB) + common.MutedStyle.Render("  (only in B)") + "\n")
+	case workflow.ChangeRemoved:
+		sb.WriteString("  " + red("-") + " " + td.Name + "  " + statusText(td.StatusA) + common.MutedStyle.Render("  (only in A)") + "\n")
+	default:
+		sb.WriteString("  " + yellow("~") + " " + td.Name + "\n")
+		if td.StatusChanged() {
+			sb.WriteString("      " + common.MutedStyle.Render("status:   ") + statusText(td.StatusA) + " → " + statusText(td.StatusB) + "\n")
+		}
+		if td.DockerChanged() {
+			sb.WriteString("      " + common.MutedStyle.Render("docker:   ") + labelOrDash(td.DockerA) + " → " + labelOrDash(td.DockerB) + "\n")
+		}
+		if td.ShardsChanged() {
+			sb.WriteString("      " + common.MutedStyle.Render(fmt.Sprintf("shards:   %d → %d\n", td.ShardsA, td.ShardsB)))
+		}
+		if td.AttemptsA != td.AttemptsB {
+			sb.WriteString("      " + common.MutedStyle.Render(fmt.Sprintf("attempts: %d → %d\n", td.AttemptsA, td.AttemptsB)))
+		}
+		if td.DurationChangedSignificantly() {
+			verdict := durationVerdict(td.DurationRatio())
+			sb.WriteString("      " + common.MutedStyle.Render("duration: ") +
+				common.FormatDuration(td.DurationA) + " → " + common.FormatDuration(td.DurationB) + "  " + verdict + "\n")
+		}
+	}
+	return sb.String()
+}
+
+// --- small styling helpers, local to the dashboard diff view ---
+
+func statusText(s string) string {
+	if s == "" {
+		return common.MutedStyle.Render("-")
+	}
+	return common.StatusStyle(s).Render(s)
+}
+
+func labelOrDash(s string) string {
+	if s == "" {
+		return common.MutedStyle.Render("-")
+	}
+	return s
+}
+
+func valuePreview(v string, width int) string {
+	if v == "" {
+		return common.MutedStyle.Render("(absent)")
+	}
+	maxLen := 50
+	if width > 60 {
+		maxLen = width - 10
+	}
+	r := []rune(v)
+	if len(r) > maxLen {
+		return string(r[:maxLen-1]) + "…"
+	}
+	return v
+}
+
+func durationVerdict(ratio float64) string {
+	if ratio > 1 {
+		return lipgloss.NewStyle().Foreground(common.StatusFailed).Render(fmt.Sprintf("%.1f× slower", ratio))
+	}
+	if ratio > 0 {
+		return common.SuccessStyle.Render(fmt.Sprintf("%.1f× faster", 1/ratio))
+	}
+	return common.MutedStyle.Render("changed")
+}
+
+func green(s string) string  { return common.SuccessStyle.Render(s) }
+func red(s string) string    { return common.ErrorStyle.Render(s) }
+func yellow(s string) string { return lipgloss.NewStyle().Foreground(common.WarningColor).Render(s) }
+func warnText(s string) string {
+	return lipgloss.NewStyle().Foreground(common.WarningColor).Render(s)
+}

--- a/internal/interfaces/tui/dashboard/messages.go
+++ b/internal/interfaces/tui/dashboard/messages.go
@@ -4,6 +4,15 @@ import (
 	"github.com/lmtani/pumbaa/internal/domain/workflow"
 )
 
+// Diff messages (workflow comparison)
+type diffLoadedMsg struct {
+	diff *workflow.RunDiff
+}
+
+type diffErrorMsg struct {
+	err error
+}
+
 // Messages for dashboard model
 
 type workflowsLoadedMsg struct {

--- a/internal/interfaces/tui/dashboard/model.go
+++ b/internal/interfaces/tui/dashboard/model.go
@@ -17,12 +17,6 @@ import (
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
 )
 
-// NavigateToDebugMsg is sent when user wants to navigate to debug screen.
-// This message is handled by the parent AppModel.
-type NavigateToDebugMsg struct {
-	Workflow *workflow.Workflow
-}
-
 // VersionCheckMsg is sent when version check completes.
 type VersionCheckMsg struct {
 	Info *version.VersionInfo
@@ -67,6 +61,9 @@ type Model struct {
 	// Help overlay
 	showHelp bool
 
+	// Error detail modal (full text of the last error)
+	showError bool
+
 	// Debug transition state
 	loadingDebug    bool
 	loadingDebugID  string
@@ -91,11 +88,8 @@ type Model struct {
 	labelsInput        textinput.Model
 	labelsMessage      string // In-modal feedback message
 
-	// Navigation state
-	ShouldQuit        bool
-	LastError         error              // Last error for telemetry capture
-	pendingNavigation tea.Cmd            // Pending navigation command for parent
-	pendingWorkflow   *workflow.Workflow // Workflow to navigate to
+	// LastError keeps the most recent error for telemetry and the error modal.
+	LastError error
 }
 
 // FilterState holds the current filter configuration
@@ -140,7 +134,7 @@ func NewModelWithRepository(repo ports.WorkflowRepository, version string) Model
 
 // HasActiveModal returns true if there's an active modal being displayed.
 func (m *Model) HasActiveModal() bool {
-	return m.showFilter || m.showConfirm || m.showLabelsModal || m.showHelp
+	return m.showFilter || m.showConfirm || m.showLabelsModal || m.showHelp || m.showError
 }
 
 // Init implements tea.Model.
@@ -226,15 +220,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case debugMetadataLoadedMsg:
 		m.loadingDebug = false
 		m.loadingDebugID = ""
-		// Parse metadata and set up navigation
+		// Parse metadata and hand navigation to the parent AppModel
 		wf, err := m.metadataFetcher.ParseMetadata(msg.metadata)
 		if err != nil {
 			m.setStatusMessage("✗ Failed to parse metadata")
 			m.LastError = err
 			return m, getClearStatusCmd()
 		}
-		m.SetPendingNavigation(wf)
-		return m, nil
+		return m, common.NavigateCmd(common.NavigateToDebugMsg{Workflow: wf})
 
 	case debugMetadataErrorMsg:
 		m.loadingDebug = false
@@ -303,6 +296,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Error detail modal
+		if m.showError {
+			return m.handleErrorModalKeys(msg)
+		}
+
 		// Handle confirmation modal first
 		if m.showConfirm {
 			return m.handleConfirmKeys(msg)
@@ -331,26 +329,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // - view_table.go: renderTable(), renderWorkflowRow(), getColumnWidths()
 // - view_footer.go: renderFooter()
 // Helper functions are in helpers.go
-
-// GetNavigationCmd returns a pending navigation command, if any.
-// This is used by the parent AppModel to check if the dashboard wants to navigate.
-func (m *Model) GetNavigationCmd() tea.Cmd {
-	return m.pendingNavigation
-}
-
-// ClearNavigation clears the pending navigation state.
-func (m *Model) ClearNavigation() {
-	m.pendingNavigation = nil
-	m.pendingWorkflow = nil
-}
-
-// SetPendingNavigation sets a navigation command to be executed by the parent.
-func (m *Model) SetPendingNavigation(wf *workflow.Workflow) {
-	m.pendingWorkflow = wf
-	m.pendingNavigation = func() tea.Msg {
-		return NavigateToDebugMsg{Workflow: wf}
-	}
-}
 
 // setStatusMessage sets a temporary status message that auto-clears after 3 seconds.
 func (m *Model) setStatusMessage(message string) {

--- a/internal/interfaces/tui/dashboard/model.go
+++ b/internal/interfaces/tui/dashboard/model.go
@@ -11,7 +11,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/charmbracelet/bubbles/viewport"
+
 	"github.com/lmtani/pumbaa/internal/application/ports"
+	workflowapp "github.com/lmtani/pumbaa/internal/application/workflow"
 	"github.com/lmtani/pumbaa/internal/domain/workflow"
 	"github.com/lmtani/pumbaa/internal/infrastructure/version"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
@@ -63,6 +66,16 @@ type Model struct {
 
 	// Error detail modal (full text of the last error)
 	showError bool
+
+	// Compare / diff state
+	compareUC       *workflowapp.CompareUseCase
+	compareBaseID   string // Workflow marked as the comparison base ("" if none)
+	compareBaseName string
+	showDiff        bool
+	diffLoading     bool
+	diffViewport    viewport.Model
+	diffResult      *workflow.RunDiff
+	diffError       string
 
 	// Debug transition state
 	loadingDebug    bool
@@ -119,14 +132,16 @@ func NewModel() Model {
 
 // NewModelWithRepository creates a new dashboard model with all repository capabilities.
 // The repository satisfies WorkflowQuerier, WorkflowAborter, WorkflowMetadataFetcher,
-// HealthChecker, and LabelManager through interface composition.
-func NewModelWithRepository(repo ports.WorkflowRepository, version string) Model {
+// HealthChecker, and LabelManager through interface composition. compareUC may be
+// nil, in which case the compare feature is disabled.
+func NewModelWithRepository(repo ports.WorkflowRepository, compareUC *workflowapp.CompareUseCase, version string) Model {
 	m := NewModel()
 	m.querier = repo
 	m.aborter = repo
 	m.metadataFetcher = repo
 	m.healthChecker = repo
 	m.labelManager = repo
+	m.compareUC = compareUC
 	m.currentVersion = version
 	m.loading = true
 	return m
@@ -144,7 +159,7 @@ func (m *Model) ResumeCmd() tea.Cmd {
 
 // HasActiveModal returns true if there's an active modal being displayed.
 func (m *Model) HasActiveModal() bool {
-	return m.showFilter || m.showConfirm || m.showLabelsModal || m.showHelp || m.showError
+	return m.showFilter || m.showConfirm || m.showLabelsModal || m.showHelp || m.showError || m.showDiff
 }
 
 // Init implements tea.Model.
@@ -188,10 +203,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.filterInput.Width = minInt(40, m.width-20)
 
 	case spinner.TickMsg:
-		if m.loading || m.loadingDebug || m.labelsLoading || m.labelsUpdating || m.statusMsg != "" {
+		if m.loading || m.loadingDebug || m.labelsLoading || m.labelsUpdating || m.diffLoading || m.statusMsg != "" {
 			m.spinner, cmd = m.spinner.Update(msg)
 			cmds = append(cmds, cmd)
 		}
+
+	case diffLoadedMsg:
+		m.diffLoading = false
+		m.diffResult = msg.diff
+		m.setDiffContent()
+		return m, nil
+
+	case diffErrorMsg:
+		m.diffLoading = false
+		m.diffError = friendlyError(msg.err)
+		m.LastError = msg.err
+		return m, nil
 
 	case workflowsLoadedMsg:
 		m.loading = false
@@ -309,6 +336,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Error detail modal
 		if m.showError {
 			return m.handleErrorModalKeys(msg)
+		}
+
+		// Diff modal
+		if m.showDiff {
+			return m.handleDiffModalKeys(msg)
 		}
 
 		// Handle confirmation modal first

--- a/internal/interfaces/tui/dashboard/model.go
+++ b/internal/interfaces/tui/dashboard/model.go
@@ -132,6 +132,16 @@ func NewModelWithRepository(repo ports.WorkflowRepository, version string) Model
 	return m
 }
 
+// ResumeCmd re-arms self-perpetuating timers (the spinner) whose tick chain
+// dies while the screen is hidden, since spinner ticks are only routed to
+// the focused screen.
+func (m *Model) ResumeCmd() tea.Cmd {
+	if m.loading || m.loadingDebug || m.labelsLoading || m.labelsUpdating {
+		return m.spinner.Tick
+	}
+	return nil
+}
+
 // HasActiveModal returns true if there's an active modal being displayed.
 func (m *Model) HasActiveModal() bool {
 	return m.showFilter || m.showConfirm || m.showLabelsModal || m.showHelp || m.showError

--- a/internal/interfaces/tui/dashboard/types.go
+++ b/internal/interfaces/tui/dashboard/types.go
@@ -21,6 +21,7 @@ type KeyMap struct {
 	LabelsManager key.Binding // Open labels modal for selected workflow
 	AutoRefresh   key.Binding
 	Help          key.Binding
+	ErrorDetail   key.Binding // Show full text of the last error
 }
 
 // DefaultKeyMap returns the default key bindings for the dashboard.
@@ -70,6 +71,10 @@ func DefaultKeyMap() KeyMap {
 		Help: key.NewBinding(
 			key.WithKeys("?"),
 			key.WithHelp("?", "help"),
+		),
+		ErrorDetail: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "error details"),
 		),
 	}
 }

--- a/internal/interfaces/tui/dashboard/types.go
+++ b/internal/interfaces/tui/dashboard/types.go
@@ -22,6 +22,7 @@ type KeyMap struct {
 	AutoRefresh   key.Binding
 	Help          key.Binding
 	ErrorDetail   key.Binding // Show full text of the last error
+	Compare       key.Binding // Mark base / compare two workflows
 }
 
 // DefaultKeyMap returns the default key bindings for the dashboard.
@@ -75,6 +76,10 @@ func DefaultKeyMap() KeyMap {
 		ErrorDetail: key.NewBinding(
 			key.WithKeys("e"),
 			key.WithHelp("e", "error details"),
+		),
+		Compare: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "mark base / compare"),
 		),
 	}
 }

--- a/internal/interfaces/tui/dashboard/update_keys.go
+++ b/internal/interfaces/tui/dashboard/update_keys.go
@@ -154,6 +154,11 @@ func (m Model) handleMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, getClearStatusCmd())
 		}
 
+	case key.Matches(msg, m.keys.Compare):
+		if cmd := m.handleCompareKey(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case key.Matches(msg, m.keys.Escape):
 		// Nothing to close here; let the app decide (dashboard is the root,
 		// so this triggers the quit confirmation).

--- a/internal/interfaces/tui/dashboard/update_keys.go
+++ b/internal/interfaces/tui/dashboard/update_keys.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/lmtani/pumbaa/internal/domain/workflow"
+	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
 )
 
 // handleMainKeys processes keyboard input during normal navigation.
@@ -144,9 +145,31 @@ func (m Model) handleMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.Help):
 		m.showHelp = true
+
+	case key.Matches(msg, m.keys.ErrorDetail):
+		if m.LastError != nil {
+			m.showError = true
+		} else {
+			m.setStatusMessage("No recent errors")
+			cmds = append(cmds, getClearStatusCmd())
+		}
+
+	case key.Matches(msg, m.keys.Escape):
+		// Nothing to close here; let the app decide (dashboard is the root,
+		// so this triggers the quit confirmation).
+		return m, common.NavigateCmd(common.NavigateBackMsg{})
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+// handleErrorModalKeys processes keyboard input in the error detail modal.
+func (m Model) handleErrorModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "e", "enter", "q":
+		m.showError = false
+	}
+	return m, nil
 }
 
 // handleFilterKeys processes keyboard input when filter input is active.

--- a/internal/interfaces/tui/dashboard/view.go
+++ b/internal/interfaces/tui/dashboard/view.go
@@ -22,6 +22,10 @@ func (m Model) View() string {
 		return m.renderHelpModal()
 	}
 
+	if m.showError {
+		return m.renderErrorModal()
+	}
+
 	sections := []string{m.renderHeader()}
 	if m.filterBarVisible() {
 		sections = append(sections, m.renderFilterBar())

--- a/internal/interfaces/tui/dashboard/view.go
+++ b/internal/interfaces/tui/dashboard/view.go
@@ -26,6 +26,10 @@ func (m Model) View() string {
 		return m.renderErrorModal()
 	}
 
+	if m.showDiff {
+		return m.renderDiffModal()
+	}
+
 	sections := []string{m.renderHeader()}
 	if m.filterBarVisible() {
 		sections = append(sections, m.renderFilterBar())

--- a/internal/interfaces/tui/dashboard/view_content.go
+++ b/internal/interfaces/tui/dashboard/view_content.go
@@ -102,6 +102,41 @@ func (m Model) renderFilterInput() string {
 		Render(lipgloss.Place(m.width-4, m.contentHeight()-2, lipgloss.Center, lipgloss.Center, filterBox))
 }
 
+// renderErrorModal renders the full text of the last error, since footer
+// status messages truncate it.
+func (m Model) renderErrorModal() string {
+	width := minInt(m.width-8, 100)
+	if width < 40 {
+		width = maxInt(20, m.width-4)
+	}
+
+	detail := "No error details available"
+	if m.LastError != nil {
+		detail = m.LastError.Error()
+	}
+
+	modalContent := lipgloss.JoinVertical(lipgloss.Left,
+		common.TitleStyle.Render("⚠  Last Error"),
+		"",
+		lipgloss.NewStyle().Foreground(common.ErrorSoftColor).Width(width-6).Render(detail),
+		"",
+		common.MutedStyle.Render("esc close"),
+	)
+
+	modal := common.ModalStyle.
+		Width(width).
+		Render(modalContent)
+
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		modal,
+		lipgloss.WithWhitespaceChars(" "),
+	)
+}
+
 // renderConfirmModal renders the abort confirmation modal.
 func (m Model) renderConfirmModal() string {
 	modalContent := lipgloss.JoinVertical(lipgloss.Center,

--- a/internal/interfaces/tui/dashboard/view_footer.go
+++ b/internal/interfaces/tui/dashboard/view_footer.go
@@ -82,6 +82,11 @@ func (m Model) renderFooter() string {
 		renderHint("enter", "debug"),
 		renderHint("/", "filter"),
 		renderHint("a", "abort"),
+	}
+	if m.LastError != nil {
+		hints = append(hints, renderHint("e", "error details"))
+	}
+	hints = append(hints,
 		renderHint("?", "help"),
 		renderHint("esc", "quit"),
 		renderHint("l", "label filter"),
@@ -90,7 +95,7 @@ func (m Model) renderFooter() string {
 		renderHint("s", "status"),
 		renderHint("r", "refresh"),
 		renderHint("w", "auto-refresh"),
-	}
+	)
 	prefix := strings.Join(parts, "")
 	hintBudget := m.width - 2 - lipgloss.Width(prefix)
 	help := common.FitParts(hintBudget, "  ", hints)

--- a/internal/interfaces/tui/dashboard/view_footer.go
+++ b/internal/interfaces/tui/dashboard/view_footer.go
@@ -82,6 +82,7 @@ func (m Model) renderFooter() string {
 		renderHint("enter", "debug"),
 		renderHint("/", "filter"),
 		renderHint("a", "abort"),
+		renderHint("c", "compare"),
 	}
 	if m.LastError != nil {
 		hints = append(hints, renderHint("e", "error details"))

--- a/internal/interfaces/tui/dashboard/view_header.go
+++ b/internal/interfaces/tui/dashboard/view_header.go
@@ -42,8 +42,18 @@ func (m Model) renderHeader() string {
 
 	left := brand + " " + breadcrumbs + "  " + status
 
-	// Right side: update notice, workflow count, last refresh
+	// Right side: compare-base badge, update notice, workflow count, last refresh
 	var right []string
+	if m.compareBaseID != "" {
+		base := m.compareBaseName
+		if base == "" {
+			base = truncateID(m.compareBaseID)
+		}
+		right = append(right, common.BadgeStyle.
+			Foreground(common.BadgeFg).
+			Background(common.BadgeWarnBg).
+			Render("⇄ base: "+base))
+	}
 	if m.updateInfo != nil && m.updateInfo.UpdateAvailable {
 		right = append(right, common.BadgeStyle.
 			Foreground(common.BadgeFg).

--- a/internal/interfaces/tui/debug/keys.go
+++ b/internal/interfaces/tui/debug/keys.go
@@ -33,6 +33,7 @@ type KeyMap struct {
 	ErrorDetail    key.Binding
 	NextMatch      key.Binding
 	PrevMatch      key.Binding
+	Cost           key.Binding
 }
 
 // DefaultKeyMap returns the default key bindings.
@@ -154,6 +155,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("N"),
 			key.WithHelp("N", "prev match"),
 		),
+		Cost: key.NewBinding(
+			key.WithKeys("$"),
+			key.WithHelp("$", "cost by task"),
+		),
 	}
 }
 
@@ -170,7 +175,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Details, k.ExpandAll, k.CollapseAll},
 		{k.ExpandFailures, k.NextFailure, k.PrevFailure, k.Watch, k.FailureSummary},
 		{k.Home, k.End, k.PageUp, k.PageDown},
-		{k.NextMatch, k.PrevMatch, k.ErrorDetail},
+		{k.NextMatch, k.PrevMatch, k.ErrorDetail, k.Cost},
 		{k.Copy, k.Chat, k.SplitNarrow, k.SplitWiden},
 		{k.Help, k.Quit},
 	}

--- a/internal/interfaces/tui/debug/keys.go
+++ b/internal/interfaces/tui/debug/keys.go
@@ -30,6 +30,9 @@ type KeyMap struct {
 	PrevFailure    key.Binding
 	Watch          key.Binding
 	FailureSummary key.Binding
+	ErrorDetail    key.Binding
+	NextMatch      key.Binding
+	PrevMatch      key.Binding
 }
 
 // DefaultKeyMap returns the default key bindings.
@@ -139,6 +142,18 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("F"),
 			key.WithHelp("F", "failure summary"),
 		),
+		ErrorDetail: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "error details"),
+		),
+		NextMatch: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "next match"),
+		),
+		PrevMatch: key.NewBinding(
+			key.WithKeys("N"),
+			key.WithHelp("N", "prev match"),
+		),
 	}
 }
 
@@ -155,6 +170,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Details, k.ExpandAll, k.CollapseAll},
 		{k.ExpandFailures, k.NextFailure, k.PrevFailure, k.Watch, k.FailureSummary},
 		{k.Home, k.End, k.PageUp, k.PageDown},
+		{k.NextMatch, k.PrevMatch, k.ErrorDetail},
 		{k.Copy, k.Chat, k.SplitNarrow, k.SplitWiden},
 		{k.Help, k.Quit},
 	}

--- a/internal/interfaces/tui/debug/modal_chat.go
+++ b/internal/interfaces/tui/debug/modal_chat.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
 )
 
 // handleChatContextLoaded handles the completion of context collection.
@@ -12,10 +14,40 @@ func (m Model) handleChatContextLoaded(msg chatContextLoadedMsg) (tea.Model, tea
 	m.isLoading = false
 	m.loadingMessage = ""
 
-	systemInstruction := fmt.Sprintf("%s\n\n---\n\n%s", taskDebugSystemInstruction, msg.context)
-	contextSummary := m.buildChatContextSummary(msg.errors)
-	m.SetPendingChatNavigation(systemInstruction, contextSummary)
-	return m, nil
+	navMsg := common.NavigateToChatMsg{
+		SystemInstruction: fmt.Sprintf("%s\n\n---\n\n%s", taskDebugSystemInstruction, msg.context),
+		ContextSummary:    m.buildChatContextSummary(msg.errors),
+		ContextLabel:      m.buildChatContextLabel(),
+	}
+	return m, common.NavigateCmd(navMsg)
+}
+
+// buildChatContextLabel builds the breadcrumb-style badge shown in the chat
+// header, e.g. "my-workflow ▸ align_reads".
+func (m Model) buildChatContextLabel() string {
+	var wfName string
+	if m.metadata != nil {
+		wfName = m.metadata.Name
+	}
+
+	var taskName string
+	if m.chatContextNode != nil {
+		taskName = m.chatContextNode.Name
+		if taskName == "" && m.chatContextNode.CallData != nil {
+			taskName = m.chatContextNode.CallData.Name
+		}
+	}
+
+	switch {
+	case wfName != "" && taskName != "":
+		return wfName + " ▸ " + taskName
+	case taskName != "":
+		return taskName
+	case wfName != "":
+		return wfName
+	default:
+		return "Task Context"
+	}
 }
 
 func (m Model) buildChatContextSummary(errors []string) string {

--- a/internal/interfaces/tui/debug/modal_cost.go
+++ b/internal/interfaces/tui/debug/modal_cost.go
@@ -1,0 +1,163 @@
+package debug
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
+	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
+)
+
+// openCostModal builds the per-task cost breakdown from the loaded metadata
+// and opens it in a scrollable modal.
+func (m Model) openCostModal() (tea.Model, tea.Cmd) {
+	m.activeModal = ModalCost
+	m.costViewport = viewport.New(m.width-10, m.height-8)
+	m.costViewport.SetContent(m.buildCostContent())
+	return m, nil
+}
+
+func (m Model) renderCostModal() string {
+	title := titleStyle.Render("Cost by Task (most expensive first)")
+	content := renderModalViewportContent(m.costViewport.View(), m.costViewport.Width, false, "")
+	footer := m.modalFooterWithHints("↑↓ scroll", "PgUp/PgDn page", "esc close")
+	return m.renderStandardModal(title, content, footer)
+}
+
+func (m Model) handleCostModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	actions := viewportModalActions{
+		onClose: func(m *Model) { m.activeModal = ModalNone },
+	}
+	cmd, handled := m.handleViewportModalKeys(msg, &m.costViewport, actions)
+	if handled {
+		return m, cmd
+	}
+	return m, nil
+}
+
+// buildCostContent renders the cost breakdown table. It shows the API total
+// (authoritative) alongside the reconstructed per-task sum, so a gap from
+// unexpanded subworkflows is visible rather than silently wrong.
+func (m Model) buildCostContent() string {
+	if m.metadata == nil {
+		return mutedStyle.Render("No metadata available")
+	}
+
+	breakdown := m.metadata.CalculateCostBreakdown()
+	if len(breakdown.Tasks) == 0 {
+		return mutedStyle.Render("No per-task cost data available (tasks have no VM cost/timing yet)")
+	}
+
+	var sb strings.Builder
+
+	// Header: authoritative API total + reconstructed coverage
+	if m.totalCost > 0 {
+		sb.WriteString(labelStyle.Render("Workflow total (API): "))
+		sb.WriteString(costBadgeStyle.Render(fmt.Sprintf("$%.2f", m.totalCost)))
+		sb.WriteString("\n")
+	}
+	sb.WriteString(mutedStyle.Render(fmt.Sprintf("Accounted here: $%.2f across %d task(s)",
+		breakdown.TotalCost, len(breakdown.Tasks))))
+	if !breakdown.FromActual {
+		sb.WriteString(mutedStyle.Render("  (some values estimated from resources)"))
+	}
+	sb.WriteString("\n")
+	if breakdown.SubworkflowsPending > 0 {
+		sb.WriteString(infoNoteStyle.Render(fmt.Sprintf(
+			"⚠ %d subworkflow(s) not expanded — their tasks are missing. Press f or open them to include.",
+			breakdown.SubworkflowsPending)))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+
+	// Column widths
+	maxNameLen := 20
+	for _, t := range breakdown.Tasks {
+		if len(t.Name) > maxNameLen {
+			maxNameLen = len(t.Name)
+		}
+	}
+	if maxNameLen > 44 {
+		maxNameLen = 44
+	}
+
+	maxCost := breakdown.Tasks[0].TotalCost // sorted desc
+
+	for _, t := range breakdown.Tasks {
+		sb.WriteString(m.formatCostRow(t, maxNameLen, maxCost))
+		sb.WriteString("\n")
+	}
+
+	// Optimization hint: the biggest non-preemptible task is the prime target
+	if tip := costOptimizationHint(breakdown); tip != "" {
+		sb.WriteString("\n")
+		sb.WriteString(infoNoteStyle.Render(tip))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+func (m Model) formatCostRow(t workflow.TaskCost, maxNameLen int, maxCost float64) string {
+	name := common.PadRight(t.Name, maxNameLen)
+
+	cost := fmt.Sprintf("$%7.2f", t.TotalCost)
+	pct := fmt.Sprintf("%5.1f%%", t.Percent)
+
+	// Cost bar proportional to the most expensive task
+	barWidth := 20
+	filled := 0
+	if maxCost > 0 {
+		filled = int(t.TotalCost / maxCost * float64(barWidth))
+	}
+	if filled > barWidth {
+		filled = barWidth
+	}
+	bar := mutedStyle.Render("[") +
+		valueStyle.Render(strings.Repeat("█", filled)) +
+		mutedStyle.Render(strings.Repeat("░", barWidth-filled)+"]")
+
+	// Preemptible marker: flag expensive non-preemptible tasks (optimization target)
+	marker := "  "
+	if !t.Preemptible {
+		if t.Percent >= 15 {
+			marker = warnMarkerStyle.Render("◆ ") // costly & on-demand: worth making preemptible
+		} else {
+			marker = mutedStyle.Render("· ")
+		}
+	}
+
+	meta := mutedStyle.Render(fmt.Sprintf("%.1fh", t.VMHours))
+	if t.ShardCount > 1 {
+		meta += mutedStyle.Render(fmt.Sprintf(" ×%d", t.ShardCount))
+	}
+	if !t.Preemptible {
+		meta += mutedStyle.Render(" on-demand")
+	} else {
+		meta += mutedStyle.Render(" preempt")
+	}
+
+	return fmt.Sprintf("%s%s  %s %s  %s  %s",
+		marker, name,
+		valueStyle.Render(cost), mutedStyle.Render(pct),
+		bar, meta)
+}
+
+// costOptimizationHint points at the biggest on-demand task, the usual
+// candidate for switching to preemptible VMs.
+func costOptimizationHint(b *workflow.CostBreakdown) string {
+	for _, t := range b.Tasks {
+		if !t.Preemptible && t.Percent >= 15 {
+			return fmt.Sprintf("◆ %s is %.0f%% of cost on on-demand VMs (%.1fh) — making it preemptible could cut cost substantially.",
+				t.Name, t.Percent, t.VMHours)
+		}
+	}
+	return ""
+}
+
+// warnMarkerStyle highlights expensive on-demand tasks.
+var warnMarkerStyle = lipgloss.NewStyle().Foreground(common.StatusRunning).Bold(true)

--- a/internal/interfaces/tui/debug/modal_cost.go
+++ b/internal/interfaces/tui/debug/modal_cost.go
@@ -1,6 +1,7 @@
 package debug
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -12,13 +13,69 @@ import (
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
 )
 
-// openCostModal builds the per-task cost breakdown from the loaded metadata
-// and opens it in a scrollable modal.
+// costBreakdownLoadedMsg carries the complete cost breakdown after the fully
+// expanded metadata was fetched.
+type costBreakdownLoadedMsg struct {
+	breakdown *workflow.CostBreakdown
+}
+
+// costBreakdownErrorMsg reports a failure to load the expanded metadata for
+// the cost breakdown.
+type costBreakdownErrorMsg struct {
+	err error
+}
+
+// openCostModal opens the per-task cost breakdown. It shows the breakdown
+// from the already-loaded tree immediately, and — so subworkflow costs are
+// included by default — fetches the fully expanded metadata in the background
+// (one call) when some subworkflows haven't been loaded, then swaps in the
+// complete breakdown. The complete breakdown is cached until the metadata
+// changes (watch refresh).
 func (m Model) openCostModal() (tea.Model, tea.Cmd) {
 	m.activeModal = ModalCost
 	m.costViewport = viewport.New(m.width-10, m.height-8)
+
+	var cmd tea.Cmd
+	display := m.displayCostBreakdown()
+	if m.costBreakdown == nil && display.SubworkflowsPending > 0 && m.fetcher != nil && !m.costLoading {
+		m.costLoading = true
+		m.costError = ""
+		cmd = m.fetchExpandedCostBreakdown()
+	}
+
 	m.costViewport.SetContent(m.buildCostContent())
-	return m, nil
+	return m, cmd
+}
+
+// displayCostBreakdown returns the complete breakdown when it has been loaded,
+// otherwise the partial one computed from the currently loaded tree.
+func (m Model) displayCostBreakdown() *workflow.CostBreakdown {
+	if m.costBreakdown != nil {
+		return m.costBreakdown
+	}
+	if m.metadata == nil {
+		return &workflow.CostBreakdown{}
+	}
+	return m.metadata.CalculateCostBreakdown()
+}
+
+// fetchExpandedCostBreakdown fetches the fully expanded metadata and computes
+// the complete cost breakdown off the UI thread.
+func (m Model) fetchExpandedCostBreakdown() tea.Cmd {
+	fetcher := m.fetcher
+	workflowID := m.metadata.ID
+	return func() tea.Msg {
+		ctx := context.Background()
+		data, err := fetcher.GetRawMetadataWithOptions(ctx, workflowID, true)
+		if err != nil {
+			return costBreakdownErrorMsg{err: err}
+		}
+		wf, err := fetcher.ParseMetadata(data)
+		if err != nil {
+			return costBreakdownErrorMsg{err: err}
+		}
+		return costBreakdownLoadedMsg{breakdown: wf.CalculateCostBreakdown()}
+	}
 }
 
 func (m Model) renderCostModal() string {
@@ -40,15 +97,18 @@ func (m Model) handleCostModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // buildCostContent renders the cost breakdown table. It shows the API total
-// (authoritative) alongside the reconstructed per-task sum, so a gap from
-// unexpanded subworkflows is visible rather than silently wrong.
+// (authoritative) alongside the reconstructed per-task sum, and reports
+// whether subworkflow costs are still loading or missing.
 func (m Model) buildCostContent() string {
 	if m.metadata == nil {
 		return mutedStyle.Render("No metadata available")
 	}
 
-	breakdown := m.metadata.CalculateCostBreakdown()
+	breakdown := m.displayCostBreakdown()
 	if len(breakdown.Tasks) == 0 {
+		if m.costLoading {
+			return mutedStyle.Render("⏳ Loading subworkflow costs...")
+		}
 		return mutedStyle.Render("No per-task cost data available (tasks have no VM cost/timing yet)")
 	}
 
@@ -66,9 +126,16 @@ func (m Model) buildCostContent() string {
 		sb.WriteString(mutedStyle.Render("  (some values estimated from resources)"))
 	}
 	sb.WriteString("\n")
-	if breakdown.SubworkflowsPending > 0 {
+	switch {
+	case m.costLoading:
+		sb.WriteString(infoNoteStyle.Render("⏳ Loading subworkflow costs — totals will update shortly..."))
+		sb.WriteString("\n")
+	case m.costError != "":
+		sb.WriteString(infoNoteStyle.Render("⚠ Could not load subworkflow costs: " + common.Truncate(m.costError, 60)))
+		sb.WriteString("\n")
+	case breakdown.SubworkflowsPending > 0:
 		sb.WriteString(infoNoteStyle.Render(fmt.Sprintf(
-			"⚠ %d subworkflow(s) not expanded — their tasks are missing. Press f or open them to include.",
+			"⚠ %d subworkflow(s) not included (no server connection to expand).",
 			breakdown.SubworkflowsPending)))
 		sb.WriteString("\n")
 	}

--- a/internal/interfaces/tui/debug/modal_dispatch.go
+++ b/internal/interfaces/tui/debug/modal_dispatch.go
@@ -95,6 +95,12 @@ func (m Model) modalDispatches() []modalDispatch {
 			handle: Model.handleErrorModalKeys,
 			resize: func(m *Model) { m.resizeStandardModalViewport(&m.errorModalViewport) },
 		},
+		{
+			active: func(m Model) bool { return m.activeModal == ModalCost },
+			view:   Model.renderCostModal,
+			handle: Model.handleCostModalKeys,
+			resize: func(m *Model) { m.resizeStandardModalViewport(&m.costViewport) },
+		},
 	}
 }
 

--- a/internal/interfaces/tui/debug/modal_dispatch.go
+++ b/internal/interfaces/tui/debug/modal_dispatch.go
@@ -89,6 +89,12 @@ func (m Model) modalDispatches() []modalDispatch {
 			handle: Model.handleFailureSummaryModalKeys,
 			resize: func(m *Model) { m.resizeStandardModalViewport(&m.failureSummaryViewport) },
 		},
+		{
+			active: func(m Model) bool { return m.activeModal == ModalError },
+			view:   Model.renderErrorModal,
+			handle: Model.handleErrorModalKeys,
+			resize: func(m *Model) { m.resizeStandardModalViewport(&m.errorModalViewport) },
+		},
 	}
 }
 

--- a/internal/interfaces/tui/debug/modal_error.go
+++ b/internal/interfaces/tui/debug/modal_error.go
@@ -1,0 +1,42 @@
+package debug
+
+import (
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// openErrorModal shows the full text of the last error. Footer status
+// messages truncate errors to keep the bar on one line; this modal is the
+// place to read (and copy) the whole thing.
+func (m Model) openErrorModal() (tea.Model, tea.Cmd) {
+	if m.lastError == "" {
+		m.setStatusMessage("No recent errors")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalError
+	m.errorModalViewport = viewport.New(m.width-10, m.height-8)
+	m.errorModalViewport.SetContent(wrapText(m.lastError, m.width-12))
+	return m, nil
+}
+
+func (m Model) renderErrorModal() string {
+	title := titleStyle.Render("⚠  Last Error")
+	content := renderModalViewportContent(m.errorModalViewport.View(), m.errorModalViewport.Width, false, "")
+	return m.renderStandardModal(title, content, m.modalFooter())
+}
+
+func (m Model) handleErrorModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	actions := viewportModalActions{
+		onClose: func(m *Model) {
+			m.activeModal = ModalNone
+		},
+		onCopy: func(m *Model) tea.Cmd {
+			return copyToClipboard(m.lastError, "error details")
+		},
+	}
+	cmd, handled := m.handleViewportModalKeys(msg, &m.errorModalViewport, actions)
+	if handled {
+		return m, cmd
+	}
+	return m, nil
+}

--- a/internal/interfaces/tui/debug/modal_kind.go
+++ b/internal/interfaces/tui/debug/modal_kind.go
@@ -19,4 +19,5 @@ const (
 	ModalCopyMenu
 	ModalFailureSummary
 	ModalError
+	ModalCost
 )

--- a/internal/interfaces/tui/debug/modal_kind.go
+++ b/internal/interfaces/tui/debug/modal_kind.go
@@ -18,4 +18,5 @@ const (
 	ModalBatchLogs
 	ModalCopyMenu
 	ModalFailureSummary
+	ModalError
 )

--- a/internal/interfaces/tui/debug/model.go
+++ b/internal/interfaces/tui/debug/model.go
@@ -149,8 +149,12 @@ type Model struct {
 	lastError          string
 	errorModalViewport viewport.Model
 
-	// Cost breakdown modal state ($ key)
-	costViewport viewport.Model
+	// Cost breakdown modal state ($ key). costBreakdown caches the complete
+	// breakdown (all subworkflows included) once fetched; nil until then.
+	costViewport  viewport.Model
+	costBreakdown *workflow.CostBreakdown
+	costLoading   bool
+	costError     string
 
 	// Components
 	keys           KeyMap

--- a/internal/interfaces/tui/debug/model.go
+++ b/internal/interfaces/tui/debug/model.go
@@ -142,12 +142,12 @@ type Model struct {
 	chatTools  []tool.Tool
 	sessionSvc adksession.Service
 
-	// Navigation state
-	NavigateToChatSystemInstruction string  // Deprecated: use pendingNavigation
-	NavigateToChatContextSummary    string  // Deprecated: use pendingNavigation
-	pendingNavigation               tea.Cmd // Pending navigation command for parent
-	wantsToGoBack                   bool    // True when user wants to go back to previous screen
-	canGoBack                       bool    // True if ESC should go back, false if ESC should quit
+	// canGoBack controls whether the footer advertises ESC as "back" or "quit"
+	canGoBack bool
+
+	// Error detail modal state (full text of the last error, e key)
+	lastError          string
+	errorModalViewport viewport.Model
 
 	// Components
 	keys           KeyMap
@@ -234,63 +234,13 @@ func (m Model) Init() tea.Cmd {
 	)
 }
 
-// NavigateToChatMsg is sent when user wants to navigate to chat screen.
-type NavigateToChatMsg struct {
-	SystemInstruction string
-	ContextSummary    string
-}
-
-// GetNavigationCmd returns a pending navigation command, if any.
-func (m *Model) GetNavigationCmd() tea.Cmd {
-	return m.pendingNavigation
-}
-
-// ClearNavigation clears the pending navigation state.
-func (m *Model) ClearNavigation() {
-	m.pendingNavigation = nil
-	m.NavigateToChatSystemInstruction = ""
-	m.NavigateToChatContextSummary = ""
-	m.wantsToGoBack = false
-}
-
-// ShouldGoBack returns true if the user wants to navigate back.
-func (m *Model) ShouldGoBack() bool {
-	return m.wantsToGoBack
-}
-
-// SetPendingChatNavigation sets a navigation command to open chat.
-func (m *Model) SetPendingChatNavigation(systemInstruction, contextSummary string) {
-	m.NavigateToChatSystemInstruction = systemInstruction
-	m.NavigateToChatContextSummary = contextSummary
-	m.pendingNavigation = func() tea.Msg {
-		return NavigateToChatMsg{
-			SystemInstruction: systemInstruction,
-			ContextSummary:    contextSummary,
-		}
-	}
-}
-
-// HasActiveModal returns true if there's an active modal being displayed.
-func (m *Model) HasActiveModal() bool {
-	return m.activeModal != ModalNone
-}
-
-// GetViewMode returns the current view mode.
-func (m *Model) GetViewMode() ViewMode {
-	return m.viewMode
-}
-
-// IsSearchActive returns true if search mode is active.
-func (m *Model) IsSearchActive() bool {
-	return m.searchActive
-}
-
 // SetCanGoBack sets whether ESC should show "back" or "quit" in the footer.
 func (m *Model) SetCanGoBack(canGoBack bool) {
 	m.canGoBack = canGoBack
 }
 
-// CanGoBack returns whether ESC should go back or quit.
-func (m *Model) CanGoBack() bool {
-	return m.canGoBack
+// HasOngoingWork reports whether background work (watch mode, an in-flight
+// fetch) would be interrupted by quitting.
+func (m *Model) HasOngoingWork() bool {
+	return m.watchActive || m.isLoading
 }

--- a/internal/interfaces/tui/debug/model.go
+++ b/internal/interfaces/tui/debug/model.go
@@ -244,3 +244,13 @@ func (m *Model) SetCanGoBack(canGoBack bool) {
 func (m *Model) HasOngoingWork() bool {
 	return m.watchActive || m.isLoading
 }
+
+// ResumeCmd re-arms self-perpetuating timers (the loading spinner) whose
+// tick chain dies while the screen is hidden, since spinner ticks are only
+// routed to the focused screen.
+func (m *Model) ResumeCmd() tea.Cmd {
+	if m.isLoading {
+		return m.loadingSpinner.Tick
+	}
+	return nil
+}

--- a/internal/interfaces/tui/debug/model.go
+++ b/internal/interfaces/tui/debug/model.go
@@ -149,6 +149,9 @@ type Model struct {
 	lastError          string
 	errorModalViewport viewport.Model
 
+	// Cost breakdown modal state ($ key)
+	costViewport viewport.Model
+
 	// Components
 	keys           KeyMap
 	help           help.Model

--- a/internal/interfaces/tui/debug/quick_actions.go
+++ b/internal/interfaces/tui/debug/quick_actions.go
@@ -1,0 +1,217 @@
+package debug
+
+import (
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// quickAction couples a quick-action key with its footer label and behavior,
+// so key dispatch and the footer hints derive from the same table and can
+// never drift.
+type quickAction struct {
+	key     string             // primary key, shown in the footer
+	alias   string             // optional secondary key
+	label   string             // footer description
+	visible func(m Model) bool // nil = always advertised in the footer
+	run     func(m Model, node *TreeNode) (tea.Model, tea.Cmd)
+}
+
+// quickActionsFor returns the quick actions available for the node type.
+func (m Model) quickActionsFor(node *TreeNode) []quickAction {
+	switch node.Type {
+	case NodeTypeWorkflow, NodeTypeSubWorkflow:
+		return workflowQuickActions()
+	case NodeTypeCall:
+		if len(node.Children) > 0 {
+			// Scatter node: no quick actions
+			return nil
+		}
+		return taskQuickActions()
+	case NodeTypeShard:
+		return taskQuickActions()
+	}
+	return nil
+}
+
+func workflowQuickActions() []quickAction {
+	return []quickAction{
+		{key: "1", label: "inputs", run: Model.openWorkflowInputs},
+		{key: "2", label: "outputs", run: Model.openWorkflowOutputs},
+		{key: "3", label: "options", run: Model.openWorkflowOptions},
+		{key: "4", label: "timeline", run: Model.openWorkflowTimeline},
+		{key: "5", label: "log", run: Model.openWorkflowLogModal},
+	}
+}
+
+func taskQuickActions() []quickAction {
+	return []quickAction{
+		{key: "1", label: "inputs", run: Model.openCallInputs},
+		{key: "2", label: "outputs", run: Model.openCallOutputs},
+		{key: "3", label: "cmd", run: Model.openCallCommand},
+		{key: "4", label: "logs", run: Model.openTaskLogs},
+		{key: "5", label: "efficiency", run: Model.openTaskEfficiency},
+		{
+			key:     "a",
+			alias:   "6",
+			label:   "chat",
+			visible: func(m Model) bool { return m.llm != nil },
+			run:     Model.openChatSelectionModal,
+		},
+	}
+}
+
+// workflowMetaFor returns the metadata backing a workflow/subworkflow node,
+// falling back to the root workflow when the subworkflow isn't loaded yet.
+func (m Model) workflowMetaFor(node *TreeNode) *WorkflowMetadata {
+	if node.Type == NodeTypeSubWorkflow && node.CallData != nil && node.CallData.SubWorkflowMetadata != nil {
+		return node.CallData.SubWorkflowMetadata
+	}
+	return m.metadata
+}
+
+// Workflow/subworkflow quick actions
+
+func (m Model) openWorkflowInputs(node *TreeNode) (tea.Model, tea.Cmd) {
+	meta := m.workflowMetaFor(node)
+	if meta.SubmittedInputs == "" {
+		m.setStatusMessage("No inputs available")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalInputs
+	m.inputsModalViewport = viewport.New(m.width-10, m.height-8)
+	m.inputsModalViewport.SetContent(m.formatWorkflowInputsForModal())
+	return m, nil
+}
+
+func (m Model) openWorkflowOutputs(node *TreeNode) (tea.Model, tea.Cmd) {
+	meta := m.workflowMetaFor(node)
+	if len(meta.Outputs) == 0 {
+		m.setStatusMessage("No outputs available")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalOutputs
+	m.outputsModalViewport = viewport.New(m.width-10, m.height-8)
+	m.outputsModalViewport.SetContent(m.formatWorkflowOutputsForModal())
+	return m, nil
+}
+
+func (m Model) openWorkflowOptions(node *TreeNode) (tea.Model, tea.Cmd) {
+	meta := m.workflowMetaFor(node)
+	if meta.SubmittedOptions == "" {
+		m.setStatusMessage("No options available")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalOptions
+	m.optionsModalViewport = viewport.New(m.width-10, m.height-8)
+	m.optionsModalViewport.SetContent(m.formatOptionsForModal())
+	return m, nil
+}
+
+func (m Model) openWorkflowTimeline(node *TreeNode) (tea.Model, tea.Cmd) {
+	meta := m.workflowMetaFor(node)
+	m.activeModal = ModalGlobalTimeline
+	m.globalTimelineTitle = meta.Name
+	m.globalTimelineViewport = viewport.New(m.width-10, m.height-8)
+	m.globalTimelineViewport.SetContent(m.buildGlobalTimelineContentForMetadata(meta))
+	return m, nil
+}
+
+func (m Model) openWorkflowLogModal(node *TreeNode) (tea.Model, tea.Cmd) {
+	meta := m.workflowMetaFor(node)
+	if meta.WorkflowLog == "" {
+		m.setStatusMessage("No workflow log available")
+		return m, getClearStatusCmd()
+	}
+	m.isLoading = true
+	m.loadingMessage = "Loading workflow log..."
+	m.loadingStartTime = time.Now()
+	return m, m.openWorkflowLog(meta.WorkflowLog)
+}
+
+// Task/shard quick actions
+
+func (m Model) openCallInputs(node *TreeNode) (tea.Model, tea.Cmd) {
+	if node.CallData == nil {
+		return m, nil
+	}
+	if len(node.CallData.Inputs) == 0 {
+		m.setStatusMessage("No inputs available")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalCallInputs
+	m.callInputsViewport = viewport.New(m.width-10, m.height-8)
+	m.callInputsViewport.SetContent(m.formatCallInputsForModal(node))
+	return m, nil
+}
+
+func (m Model) openCallOutputs(node *TreeNode) (tea.Model, tea.Cmd) {
+	if node.CallData == nil {
+		return m, nil
+	}
+	if len(node.CallData.Outputs) == 0 {
+		m.setStatusMessage("No outputs available")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalCallOutputs
+	m.callOutputsViewport = viewport.New(m.width-10, m.height-8)
+	m.callOutputsViewport.SetContent(m.formatCallOutputsForModal(node))
+	return m, nil
+}
+
+func (m Model) openCallCommand(node *TreeNode) (tea.Model, tea.Cmd) {
+	if node.CallData == nil {
+		return m, nil
+	}
+	if node.CallData.CommandLine == "" {
+		m.setStatusMessage("No command available")
+		return m, getClearStatusCmd()
+	}
+	m.activeModal = ModalCallCommand
+	m.callCommandViewport = viewport.New(m.width-10, m.height-8)
+	m.callCommandViewport.SetContent(m.formatCallCommandForModal(node))
+	return m, nil
+}
+
+func (m Model) openTaskLogs(node *TreeNode) (tea.Model, tea.Cmd) {
+	if node.CallData == nil {
+		return m, nil
+	}
+	if node.CallData.Stdout == "" && node.CallData.Stderr == "" && node.CallData.MonitoringLog == "" && !m.canShowBatchLogs(node) {
+		m.setStatusMessage("No logs available")
+		return m, getClearStatusCmd()
+	}
+	m.viewMode = ViewModeLogs
+	m.logCursor = 1 // Start at stderr
+	m.updateDetailsContent()
+	m.focus = FocusDetails
+	return m, nil
+}
+
+func (m Model) openTaskEfficiency(node *TreeNode) (tea.Model, tea.Cmd) {
+	if node.CallData == nil {
+		return m, nil
+	}
+	if node.CallData.MonitoringLog == "" {
+		m.setStatusMessage("No monitoring data available")
+		return m, getClearStatusCmd()
+	}
+	// Check cache first
+	if node.CallData.EfficiencyReport != nil {
+		m.resourceReport = node.CallData.EfficiencyReport
+		m.resourceError = ""
+		m.viewMode = ViewModeMonitor
+		m.updateDetailsContent()
+		return m, nil
+	}
+	// Not cached, load it
+	m.viewMode = ViewModeMonitor
+	m.resourceReport = nil
+	m.resourceError = ""
+	m.isLoading = true
+	m.loadingMessage = "Analyzing resource efficiency..."
+	m.loadingStartTime = time.Now()
+	m.updateDetailsContent()
+	return m, m.loadResourceAnalysis(node.CallData.MonitoringLog)
+}

--- a/internal/interfaces/tui/debug/update.go
+++ b/internal/interfaces/tui/debug/update.go
@@ -566,161 +566,19 @@ func (m Model) handleExpandOrOpenLog() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// handleQuickActions dispatches numeric quick actions through the shared
+// quickAction table (see quick_actions.go), which also drives the footer.
 func (m Model) handleQuickActions(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.cursor >= len(m.nodes) {
 		return m, nil
 	}
 
 	node := m.nodes[m.cursor]
-	keyNum := msg.String()
-
-	// Dispatch based on node type
-	switch node.Type {
-	case NodeTypeWorkflow, NodeTypeSubWorkflow:
-		return m.handleWorkflowQuickAction(keyNum, node)
-	case NodeTypeCall:
-		// Check if it's a scatter (has children) or a simple task
-		if len(node.Children) > 0 {
-			// Scatter node - no quick actions
-			return m, nil
+	pressed := msg.String()
+	for _, action := range m.quickActionsFor(node) {
+		if action.key == pressed || (action.alias != "" && action.alias == pressed) {
+			return action.run(m, node)
 		}
-		return m.handleTaskQuickAction(keyNum, node)
-	case NodeTypeShard:
-		return m.handleTaskQuickAction(keyNum, node)
-	}
-
-	return m, nil
-}
-
-// handleWorkflowQuickAction handles quick actions for Workflow and SubWorkflow nodes.
-// 1=Inputs [modal], 2=Outputs [modal], 3=Options [modal], 4=Timeline [modal], 5=Workflow Log [modal]
-func (m Model) handleWorkflowQuickAction(keyNum string, node *TreeNode) (tea.Model, tea.Cmd) {
-	// Get the appropriate metadata
-	var meta *WorkflowMetadata
-	if node.Type == NodeTypeWorkflow {
-		meta = m.metadata
-	} else if node.CallData != nil && node.CallData.SubWorkflowMetadata != nil {
-		meta = node.CallData.SubWorkflowMetadata
-	} else {
-		meta = m.metadata // Fallback to root
-	}
-
-	switch keyNum {
-	case "1": // Inputs
-		if meta.SubmittedInputs != "" {
-			m.activeModal = ModalInputs
-			m.inputsModalViewport = viewport.New(m.width-10, m.height-8)
-			m.inputsModalViewport.SetContent(m.formatWorkflowInputsForModal())
-		} else {
-			m.setStatusMessage("No inputs available")
-			return m, getClearStatusCmd()
-		}
-	case "2": // Outputs
-		if len(meta.Outputs) > 0 {
-			m.activeModal = ModalOutputs
-			m.outputsModalViewport = viewport.New(m.width-10, m.height-8)
-			m.outputsModalViewport.SetContent(m.formatWorkflowOutputsForModal())
-		} else {
-			m.setStatusMessage("No outputs available")
-			return m, getClearStatusCmd()
-		}
-	case "3": // Options
-		if meta.SubmittedOptions != "" {
-			m.activeModal = ModalOptions
-			m.optionsModalViewport = viewport.New(m.width-10, m.height-8)
-			m.optionsModalViewport.SetContent(m.formatOptionsForModal())
-		} else {
-			m.setStatusMessage("No options available")
-			return m, getClearStatusCmd()
-		}
-	case "4": // Timeline
-		m.activeModal = ModalGlobalTimeline
-		m.globalTimelineTitle = meta.Name
-		m.globalTimelineViewport = viewport.New(m.width-10, m.height-8)
-		m.globalTimelineViewport.SetContent(m.buildGlobalTimelineContentForMetadata(meta))
-	case "5": // Workflow Log
-		if meta.WorkflowLog != "" {
-			m.isLoading = true
-			m.loadingMessage = "Loading workflow log..."
-			m.loadingStartTime = time.Now()
-			return m, m.openWorkflowLog(meta.WorkflowLog)
-		}
-		m.setStatusMessage("No workflow log available")
-		return m, getClearStatusCmd()
-	}
-
-	return m, nil
-}
-
-// handleTaskQuickAction handles quick actions for Task and Shard nodes.
-// 1=Inputs [modal], 2=Outputs [modal], 3=Command [modal], 4=Logs [inline], 5=Efficiency [inline], 6=Chat
-func (m Model) handleTaskQuickAction(keyNum string, node *TreeNode) (tea.Model, tea.Cmd) {
-	if node.CallData == nil {
-		return m, nil
-	}
-
-	switch keyNum {
-	case "1": // Inputs
-		if len(node.CallData.Inputs) > 0 {
-			m.activeModal = ModalCallInputs
-			m.callInputsViewport = viewport.New(m.width-10, m.height-8)
-			m.callInputsViewport.SetContent(m.formatCallInputsForModal(node))
-		} else {
-			m.setStatusMessage("No inputs available")
-			return m, getClearStatusCmd()
-		}
-	case "2": // Outputs
-		if len(node.CallData.Outputs) > 0 {
-			m.activeModal = ModalCallOutputs
-			m.callOutputsViewport = viewport.New(m.width-10, m.height-8)
-			m.callOutputsViewport.SetContent(m.formatCallOutputsForModal(node))
-		} else {
-			m.setStatusMessage("No outputs available")
-			return m, getClearStatusCmd()
-		}
-	case "3": // Command
-		if node.CallData.CommandLine != "" {
-			m.activeModal = ModalCallCommand
-			m.callCommandViewport = viewport.New(m.width-10, m.height-8)
-			m.callCommandViewport.SetContent(m.formatCallCommandForModal(node))
-		} else {
-			m.setStatusMessage("No command available")
-			return m, getClearStatusCmd()
-		}
-	case "4": // Logs (inline)
-		if node.CallData.Stdout != "" || node.CallData.Stderr != "" || node.CallData.MonitoringLog != "" || m.canShowBatchLogs(node) {
-			m.viewMode = ViewModeLogs
-			m.logCursor = 1 // Start at stderr
-			m.updateDetailsContent()
-			m.focus = FocusDetails
-		} else {
-			m.setStatusMessage("No logs available")
-			return m, getClearStatusCmd()
-		}
-	case "5": // Efficiency (inline)
-		if node.CallData.MonitoringLog != "" {
-			// Check cache first
-			if node.CallData.EfficiencyReport != nil {
-				m.resourceReport = node.CallData.EfficiencyReport
-				m.resourceError = ""
-				m.viewMode = ViewModeMonitor
-				m.updateDetailsContent()
-				return m, nil
-			}
-			// Not cached, load it
-			m.viewMode = ViewModeMonitor
-			m.resourceReport = nil
-			m.resourceError = ""
-			m.isLoading = true
-			m.loadingMessage = "Analyzing resource efficiency..."
-			m.loadingStartTime = time.Now()
-			m.updateDetailsContent()
-			return m, m.loadResourceAnalysis(node.CallData.MonitoringLog)
-		}
-		m.setStatusMessage("No monitoring data available")
-		return m, getClearStatusCmd()
-	case "6", "a": // Chat with AI
-		return m.openChatSelectionModal(node)
 	}
 
 	return m, nil

--- a/internal/interfaces/tui/debug/update.go
+++ b/internal/interfaces/tui/debug/update.go
@@ -424,6 +424,9 @@ func (m Model) handleMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.ErrorDetail):
 		return m.openErrorModal()
 
+	case key.Matches(msg, m.keys.Cost):
+		return m.openCostModal()
+
 	case key.Matches(msg, m.keys.NextMatch):
 		if m.searchQuery != "" {
 			m.jumpToSearchMatch(true)

--- a/internal/interfaces/tui/debug/update.go
+++ b/internal/interfaces/tui/debug/update.go
@@ -106,6 +106,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.watchActive {
 			return m, nil
 		}
+		m.lastError = msg.err.Error()
 		m.setStatusMessage("Watch refresh failed: " + common.Truncate(msg.err.Error(), 60))
 		return m, tea.Batch(watchTick(), getClearStatusCmd())
 
@@ -138,6 +139,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case resourceAnalysisErrorMsg:
 		m.isLoading = false
 		m.loadingMessage = ""
+		m.lastError = msg.err.Error()
 		m.resourceError = msg.err.Error()
 		m.viewMode = ViewModeMonitor
 		m.updateDetailsContent()
@@ -169,7 +171,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case subWorkflowErrorMsg:
 		m.isLoading = false
 		m.loadingMessage = ""
-		m.setStatusMessage(fmt.Sprintf("Error loading subworkflow: %s", msg.err.Error()))
+		m.lastError = msg.err.Error()
+		m.setStatusMessage(fmt.Sprintf("Error loading subworkflow: %s", common.Truncate(msg.err.Error(), 60)))
 		if m.failureExpandActive {
 			return m, tea.Batch(getClearStatusCmd(), m.continueFailureExpansion())
 		}
@@ -197,6 +200,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case logErrorMsg:
 		m.isLoading = false
 		m.loadingMessage = ""
+		m.lastError = msg.err.Error()
 		// Show error as temporary status message instead of opening modal
 		errorMsg := msg.err.Error()
 		// Simplify common error messages
@@ -247,6 +251,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case batchLogsErrorMsg:
 		m.isLoading = false
 		m.loadingMessage = ""
+		m.lastError = msg.err.Error()
 		errorMsg := msg.err.Error()
 
 		// Simplify common error messages
@@ -269,6 +274,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case chatContextErrorMsg:
 		m.isLoading = false
 		m.loadingMessage = ""
+		m.lastError = msg.err.Error()
 		m.setStatusMessage(fmt.Sprintf("Failed to collect context: %v", msg.err))
 		return m, getClearStatusCmd()
 
@@ -383,10 +389,10 @@ func (m Model) handleMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateDetailsContent()
 
 	case key.Matches(msg, m.keys.Escape):
-		// If already in tree view, go back to previous screen
+		// If already in tree view there is nothing left to close here;
+		// hand the decision (back vs quit) to the app model.
 		if m.viewMode == ViewModeTree {
-			m.wantsToGoBack = true
-			return m, nil
+			return m, common.NavigateCmd(common.NavigateBackMsg{})
 		}
 		// Otherwise, return to tree view
 		m.viewMode = ViewModeTree
@@ -414,6 +420,19 @@ func (m Model) handleMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.FailureSummary):
 		return m.openFailureSummary()
+
+	case key.Matches(msg, m.keys.ErrorDetail):
+		return m.openErrorModal()
+
+	case key.Matches(msg, m.keys.NextMatch):
+		if m.searchQuery != "" {
+			m.jumpToSearchMatch(true)
+		}
+
+	case key.Matches(msg, m.keys.PrevMatch):
+		if m.searchQuery != "" {
+			m.jumpToSearchMatch(false)
+		}
 
 	case key.Matches(msg, m.keys.Home):
 		m.changeSelectedNode(0)

--- a/internal/interfaces/tui/debug/update.go
+++ b/internal/interfaces/tui/debug/update.go
@@ -268,6 +268,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setStatusMessage("Error loading batch logs: " + errorMsg)
 		return m, getClearStatusCmd()
 
+	case costBreakdownLoadedMsg:
+		m.costLoading = false
+		m.costError = ""
+		m.costBreakdown = msg.breakdown
+		if m.activeModal == ModalCost {
+			m.costViewport.SetContent(m.buildCostContent())
+		}
+		return m, nil
+
+	case costBreakdownErrorMsg:
+		m.costLoading = false
+		m.costError = msg.err.Error()
+		m.lastError = msg.err.Error()
+		if m.activeModal == ModalCost {
+			m.costViewport.SetContent(m.buildCostContent())
+		}
+		return m, nil
+
 	case chatContextLoadedMsg:
 		return m.handleChatContextLoaded(msg)
 

--- a/internal/interfaces/tui/debug/view_footer.go
+++ b/internal/interfaces/tui/debug/view_footer.go
@@ -10,28 +10,17 @@ import (
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
 )
 
-// loadingDuration is the expected duration for loading operations (for progress bar)
-const loadingDuration = 5 * time.Second
-
 // statusDuration is the duration for temporary status messages
 const statusDuration = 3 * time.Second
 
 func (m Model) renderFooter() string {
 	var parts []string
 
-	// Loading indicator with increasing progress bar (takes priority)
+	// Loading indicator with elapsed time (takes priority). Elapsed time is
+	// honest feedback; a synthetic progress bar would just guess.
 	if m.isLoading && m.loadingMessage != "" {
 		elapsed := time.Since(m.loadingStartTime)
-		percentage := int(elapsed.Seconds() * 100 / loadingDuration.Seconds())
-		if percentage > 100 {
-			percentage = 100
-		}
-
-		barLength := (percentage * 20) / 100 // 20 chars max
-		progressBar := " [" + strings.Repeat("━", barLength) + strings.Repeat("╌", 20-barLength) + "]"
-
-		loadingStyle := temporaryStatusStyle
-		parts = append(parts, loadingStyle.Render("⏳ "+m.loadingMessage+progressBar))
+		parts = append(parts, temporaryStatusStyle.Render(fmt.Sprintf("⏳ %s (%.1fs)", m.loadingMessage, elapsed.Seconds())))
 		parts = append(parts, " • ")
 	} else if m.statusMessage != "" {
 		// Status message with decreasing progress bar
@@ -88,28 +77,86 @@ func (m Model) renderSearchStatus() string {
 func (m Model) footerHints() []string {
 	hints := []string{
 		renderFooterHint("↑↓", "navigate"),
+	}
+
+	// Quick actions reflect what 1-5/a actually do for the selected node,
+	// instead of an opaque "1-6 actions".
+	hints = append(hints, m.quickActionHints()...)
+
+	hints = append(hints,
 		renderFooterHint("tab", "switch"),
-		renderFooterHint("d", "details"),
-		renderFooterHint("1-6", "actions"),
 		renderFooterHint("E/C", "expand/collapse"),
 		renderFooterHint("f", "failures"),
 		renderFooterHint("w", "watch"),
 		renderFooterHint("/", "search"),
-	}
+	)
 
 	if m.searchQuery != "" || m.searchActive {
+		hints = append(hints, renderFooterHint("n/N", "matches"))
 		hints = append(hints, renderFooterHint("ctrl+x", "clear"))
 	}
 
-	hints = append(hints, renderFooterHint("?", "help"))
-
-	// Show "back" or "quit" depending on whether we can go back
-	if m.canGoBack {
-		hints = append(hints, renderFooterHint("esc", "back"))
-	} else {
-		hints = append(hints, renderFooterHint("esc", "quit"))
+	if m.lastError != "" {
+		hints = append(hints, renderFooterHint("e", "error details"))
 	}
 
+	hints = append(hints, renderFooterHint("?", "help"))
+	hints = append(hints, renderFooterHint("esc", m.escHint()))
+
+	return hints
+}
+
+// escHint describes what ESC does right now, so the footer never lies.
+func (m Model) escHint() string {
+	switch {
+	case m.searchActive:
+		return "exit search"
+	case m.viewMode != ViewModeTree:
+		return "tree view"
+	case m.canGoBack:
+		return "back"
+	default:
+		return "quit"
+	}
+}
+
+// quickActionHints returns the numeric quick actions available for the
+// currently selected node.
+func (m Model) quickActionHints() []string {
+	if m.cursor >= len(m.nodes) {
+		return nil
+	}
+
+	node := m.nodes[m.cursor]
+	switch node.Type {
+	case NodeTypeWorkflow, NodeTypeSubWorkflow:
+		return []string{
+			renderFooterHint("1", "inputs"),
+			renderFooterHint("2", "outputs"),
+			renderFooterHint("3", "options"),
+			renderFooterHint("4", "timeline"),
+			renderFooterHint("5", "log"),
+		}
+	case NodeTypeCall:
+		if len(node.Children) > 0 {
+			// Scatter node: no quick actions
+			return nil
+		}
+	case NodeTypeShard:
+	default:
+		return nil
+	}
+
+	hints := []string{
+		renderFooterHint("1", "inputs"),
+		renderFooterHint("2", "outputs"),
+		renderFooterHint("3", "cmd"),
+		renderFooterHint("4", "logs"),
+		renderFooterHint("5", "efficiency"),
+	}
+	if m.llm != nil {
+		hints = append(hints, renderFooterHint("a", "chat"))
+	}
 	return hints
 }
 

--- a/internal/interfaces/tui/debug/view_footer.go
+++ b/internal/interfaces/tui/debug/view_footer.go
@@ -120,42 +120,20 @@ func (m Model) escHint() string {
 	}
 }
 
-// quickActionHints returns the numeric quick actions available for the
-// currently selected node.
+// quickActionHints renders the quick actions available for the selected
+// node, straight from the same table that dispatches the keys.
 func (m Model) quickActionHints() []string {
 	if m.cursor >= len(m.nodes) {
 		return nil
 	}
 
-	node := m.nodes[m.cursor]
-	switch node.Type {
-	case NodeTypeWorkflow, NodeTypeSubWorkflow:
-		return []string{
-			renderFooterHint("1", "inputs"),
-			renderFooterHint("2", "outputs"),
-			renderFooterHint("3", "options"),
-			renderFooterHint("4", "timeline"),
-			renderFooterHint("5", "log"),
+	actions := m.quickActionsFor(m.nodes[m.cursor])
+	hints := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if action.visible != nil && !action.visible(m) {
+			continue
 		}
-	case NodeTypeCall:
-		if len(node.Children) > 0 {
-			// Scatter node: no quick actions
-			return nil
-		}
-	case NodeTypeShard:
-	default:
-		return nil
-	}
-
-	hints := []string{
-		renderFooterHint("1", "inputs"),
-		renderFooterHint("2", "outputs"),
-		renderFooterHint("3", "cmd"),
-		renderFooterHint("4", "logs"),
-		renderFooterHint("5", "efficiency"),
-	}
-	if m.llm != nil {
-		hints = append(hints, renderFooterHint("a", "chat"))
+		hints = append(hints, renderFooterHint(action.key, action.label))
 	}
 	return hints
 }

--- a/internal/interfaces/tui/debug/view_footer.go
+++ b/internal/interfaces/tui/debug/view_footer.go
@@ -88,6 +88,7 @@ func (m Model) footerHints() []string {
 		renderFooterHint("E/C", "expand/collapse"),
 		renderFooterHint("f", "failures"),
 		renderFooterHint("w", "watch"),
+		renderFooterHint("$", "cost"),
 		renderFooterHint("/", "search"),
 	)
 

--- a/internal/interfaces/tui/debug/view_help.go
+++ b/internal/interfaces/tui/debug/view_help.go
@@ -38,11 +38,12 @@ func (m Model) renderHelpOverlay() string {
 	content.WriteString(helpLine("F", "Failure summary (grouped)"))
 	content.WriteString(helpLine("w", "Watch (auto-refresh)"))
 	content.WriteString(helpLine("d", "Return to details view"))
+	content.WriteString(helpLine("$", "Cost breakdown by task"))
 	content.WriteString(helpLine("/", "Filter tree (name/status)"))
 	content.WriteString(helpLine("Ctrl+X", "Clear search"))
 	content.WriteString(helpLine("y", "Copy menu (ID, paths, cmd)"))
 	content.WriteString(helpLine("Esc", "Close modal / back"))
-	content.WriteString(helpLine("q", "Quit"))
+	content.WriteString(helpLine("Ctrl+C", "Quit"))
 	content.WriteString("\n")
 
 	// Quick actions section header

--- a/internal/interfaces/tui/debug/watch.go
+++ b/internal/interfaces/tui/debug/watch.go
@@ -92,6 +92,10 @@ func (m *Model) applyRefreshedMetadata(wf *WorkflowMetadata) ([]string, []tea.Cm
 	m.metadata = wf
 	m.preemption = wf.CalculatePreemptionSummary()
 	m.tree = tree.BuildTree(wf)
+	// The cached cost breakdown reflected the previous snapshot; drop it so
+	// the next open recomputes (and re-fetches subworkflows if needed).
+	m.costBreakdown = nil
+	m.costError = ""
 
 	var changes []string
 	var cmds []tea.Cmd

--- a/internal/interfaces/tui/dependencies.go
+++ b/internal/interfaces/tui/dependencies.go
@@ -2,6 +2,7 @@
 package tui
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
 	adkmodel "google.golang.org/adk/model"
 	adksession "google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
@@ -26,6 +27,11 @@ type Dependencies struct {
 
 	// Chat dependencies (optional - nil if LLM not configured)
 	ChatDeps *ChatDependencies
+
+	// Program is the running Bubble Tea program. Handlers set it right after
+	// tea.NewProgram (Dependencies is shared by pointer), so screens created
+	// later can push messages from goroutines (streaming, tool records).
+	Program *tea.Program
 }
 
 // ChatDependencies holds optional dependencies for chat functionality.

--- a/internal/interfaces/tui/dependencies.go
+++ b/internal/interfaces/tui/dependencies.go
@@ -24,6 +24,7 @@ type Dependencies struct {
 	// Use cases
 	MonitoringUC *workflowapp.MonitoringUseCase
 	BatchLogsUC  *workflowapp.GetBatchLogsUseCase
+	CompareUC    *workflowapp.CompareUseCase
 
 	// Chat dependencies (optional - nil if LLM not configured)
 	ChatDeps *ChatDependencies

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ nav:
     - Submit Workflow: features/submit.md
     - Query Workflows: features/query.md
     - Workflow Metadata: features/metadata.md
+    - Inputs & Outputs: features/inputs-outputs.md
+    - Diff Two Runs: features/diff.md
     - Abort Workflow: features/abort.md
     - Bundle WDL: features/bundle.md
   - AI Chat:
@@ -56,7 +58,10 @@ nav:
   - Advanced:
     - Resource Monitoring: features/resource-monitoring.md
     - Resource Analysis: features/resource-analysis.md
-  - Contributing: contributing.md
+  - Development:
+    - Contributing: contributing.md
+    - Architecture: ARCHITECTURE.md
+    - Testing Guidelines: testing-guidelines.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

This PR reworks how the TUI screens talk to each other and builds several features on top of that foundation: a smoother AI chat with streaming and resumable sessions, per-task cost breakdowns, a way to compare two workflow runs, and a documentation refresh so the docs match what the tool actually does today.

## Changes

**Navigation and UX**
- Screens now navigate through shared messages with a single coordinator, so moving between dashboard, debug, and chat keeps each screen's state (tree expansion, watch mode, filters) intact.
- Each screen owns its own keys, including ESC: it first closes whatever is open (modal, search, view mode) and only then goes back. Quitting is confirmed at the root.
- Async results are delivered to all active screens, while keystrokes go only to the focused one — fixing subtle bugs when background work finished on a screen you had left.

**AI chat**
- Responses now stream in as they are generated, and ESC cancels a generation in progress.
- Enter sends the message (Ctrl+J inserts a line break).
- Conversations persist per task: reopening the chat for the same task resumes it, Ctrl+R brings back the previous session, and Ctrl+S lists all sessions to switch between.
- The agent's tool set is now defined in one place and easier to extend. New abilities: saving files to the working directory and consulting an indexed WDL knowledge base.

**Costs and comparisons**
- New cost breakdown modal in the debug view (press `$`) showing the estimated cost of each task, including subworkflows. Costs are billed on VM lifetime rather than task wall-clock, which is closer to what the cloud actually charges.
- New run comparison: mark two workflows in the dashboard (press `c` twice) or run `pumbaa workflow diff <id-a> <id-b>` to see what changed between two executions — inputs, options, source, and per-task differences. Call-cached tasks are resolved back to their source run so timings are meaningful.

**Documentation**
- Fixed examples that failed when copied (wrong `bundle` subcommand, missing required flag, nonexistent keys and flags).
- Rewrote the architecture doc to match the current code and added it, along with the testing guidelines, to the site navigation.
- Added pages for the new diff and inputs/outputs commands, a full environment-variable reference, and up-to-date keyboard shortcut tables for all three screens.
- Removed a `--verbose` flag from the metadata command that had no effect, and fixed the in-app help overlay to list only keys that exist.

## How to test

```bash
make build
./dist/pumbaa dashboard   # navigate to debug ($ for costs, c twice for diff)
./dist/pumbaa chat        # streaming, ctrl+r / ctrl+s for sessions
make test
```

To preview the docs: `make docs-serve`.

## Notes

- No breaking changes to CLI commands, except that `workflow metadata` no longer accepts the do-nothing `--verbose` flag.
- Chat sessions are stored in `~/.pumbaa/sessions.db`.