### PR TITLE
fix(cost): keep real dollars and resource-hour estimates in separate units

### DIFF
--- a/internal/domain/workflow/cost.go
+++ b/internal/domain/workflow/cost.go
@@ -9,27 +9,40 @@ import (
 )
 
 // TaskCost is a Value Object with the aggregated cost of one task (summed
-// across its shards and attempts).
+// across its shards and attempts). Real dollars and resource estimates are
+// different units, so they are kept in separate fields and never added
+// together.
 type TaskCost struct {
-	Name         string  // Short task name (without workflow prefix)
-	TotalCost    float64 // Cost of all shards/attempts
-	VMHours      float64 // Sum of compute time across shards/attempts, in hours
-	ShardCount   int     // Number of shards
-	AttemptCount int     // Total attempts across shards
-	Preemptible  bool    // True if the task ran on preemptible VMs
-	FromActual   bool    // True when cost came from real vmCostPerHour (not an estimate)
-	Percent      float64 // Share of the workflow's TotalCost
+	Name          string
+	ActualCost    float64 // Dollars: vmCostPerHour × billed hours, for attempts that report both
+	EstimatedCost float64 // Resource-hours (cpu × memGB × hours) for attempts without real cost data
+	VMHours       float64 // Sum of billed compute time across shards/attempts, in hours
+	ShardCount    int     // Number of shards
+	AttemptCount  int     // Total attempts across shards
+	Preemptible   bool    // True if the task ran on preemptible VMs
+	// Percent is the task's share within its unit: of the workflow's actual
+	// dollars when any exist, otherwise of the estimated resource-hours.
+	Percent float64
 }
 
 // CostBreakdown is a Value Object with per-task costs for a workflow,
-// sorted by cost descending.
+// sorted by actual cost (then estimate) descending.
 type CostBreakdown struct {
-	Tasks      []TaskCost
-	TotalCost  float64 // Sum of Tasks' cost (reconstructed from loaded metadata)
-	FromActual bool    // True when every task's cost came from real vmCostPerHour
+	Tasks []TaskCost
+	// ActualTotal is the sum of real dollar costs (reconstructed from loaded
+	// metadata). EstimatedTotal is the sum of resource-hours estimates — a
+	// different unit, reported separately and never added to ActualTotal.
+	ActualTotal    float64
+	EstimatedTotal float64
 	// SubworkflowsPending is the number of subworkflow calls whose metadata
 	// was not loaded, so their tasks are absent from this breakdown.
 	SubworkflowsPending int
+}
+
+// HasEstimates reports whether any attempt lacked real cost data and fell
+// back to the resource-hours estimate.
+func (b *CostBreakdown) HasEstimates() bool {
+	return b.EstimatedTotal > 0
 }
 
 // CalculateCostBreakdown aggregates the cost of every task in the workflow,
@@ -38,13 +51,12 @@ type CostBreakdown struct {
 // can tell the breakdown is partial.
 func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 	type agg struct {
-		cost       float64
-		vmHours    float64
-		shards     map[int]bool
-		attempts   int
-		preempt    bool
-		fromActual bool
-		allActual  bool
+		actual    float64
+		estimated float64
+		vmHours   float64
+		shards    map[int]bool
+		attempts  int
+		preempt   bool
 	}
 	aggregations := make(map[string]*agg)
 	var order []string
@@ -70,22 +82,20 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 
 				a := aggregations[short]
 				if a == nil {
-					a = &agg{shards: make(map[int]bool), allActual: true}
+					a = &agg{shards: make(map[int]bool)}
 					aggregations[short] = a
 					order = append(order, short)
 				}
-				cost := calculateAttemptCost(call, now)
-				a.cost += cost
+				actual, estimated := attemptCostParts(call, now)
+				a.actual += actual
+				a.estimated += estimated
 				a.attempts++
 				a.shards[call.ShardIndex] = true
 				if IsPreemptible(call.Preemptible) {
 					a.preempt = true
 				}
-				if call.VMCostPerHour > 0 && billableHours(call, now) > 0 {
+				if actual > 0 {
 					a.vmHours += billableHours(call, now)
-					a.fromActual = true
-				} else {
-					a.allActual = false
 				}
 			}
 		}
@@ -93,35 +103,73 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 	walk(w.Calls)
 
 	breakdown := &CostBreakdown{
-		FromActual:          true,
 		SubworkflowsPending: pending,
 	}
 	for _, name := range order {
 		a := aggregations[name]
-		breakdown.TotalCost += a.cost
-		if !a.allActual {
-			breakdown.FromActual = false
-		}
+		breakdown.ActualTotal += a.actual
+		breakdown.EstimatedTotal += a.estimated
 		breakdown.Tasks = append(breakdown.Tasks, TaskCost{
-			Name:         name,
-			TotalCost:    a.cost,
-			VMHours:      a.vmHours,
-			ShardCount:   len(a.shards),
-			AttemptCount: a.attempts,
-			Preemptible:  a.preempt,
-			FromActual:   a.fromActual && a.allActual,
+			Name:          name,
+			ActualCost:    a.actual,
+			EstimatedCost: a.estimated,
+			VMHours:       a.vmHours,
+			ShardCount:    len(a.shards),
+			AttemptCount:  a.attempts,
+			Preemptible:   a.preempt,
 		})
 	}
 
-	if breakdown.TotalCost > 0 {
-		for i := range breakdown.Tasks {
-			breakdown.Tasks[i].Percent = breakdown.Tasks[i].TotalCost / breakdown.TotalCost * 100
+	// Percent within a single unit: prefer real dollars; when the workflow
+	// has none (e.g. a backend that reports no cost), fall back to the
+	// estimate so relative weights are still meaningful.
+	for i := range breakdown.Tasks {
+		switch {
+		case breakdown.ActualTotal > 0:
+			breakdown.Tasks[i].Percent = breakdown.Tasks[i].ActualCost / breakdown.ActualTotal * 100
+		case breakdown.EstimatedTotal > 0:
+			breakdown.Tasks[i].Percent = breakdown.Tasks[i].EstimatedCost / breakdown.EstimatedTotal * 100
 		}
 	}
 
 	sort.Slice(breakdown.Tasks, func(i, j int) bool {
-		return breakdown.Tasks[i].TotalCost > breakdown.Tasks[j].TotalCost
+		if breakdown.Tasks[i].ActualCost != breakdown.Tasks[j].ActualCost {
+			return breakdown.Tasks[i].ActualCost > breakdown.Tasks[j].ActualCost
+		}
+		return breakdown.Tasks[i].EstimatedCost > breakdown.Tasks[j].EstimatedCost
 	})
 
 	return breakdown
+}
+
+// attemptCostParts splits one attempt's cost into its unit: real dollars when
+// Cromwell reported a VM rate and a billable window, or a resource-hours
+// estimate otherwise. Exactly one of the two is non-zero.
+func attemptCostParts(call Call, now time.Time) (actual, estimated float64) {
+	if call.VMCostPerHour > 0 {
+		if hours := billableHours(call, now); hours > 0 {
+			return call.VMCostPerHour * hours, 0
+		}
+	}
+	return 0, resourceHoursEstimate(call, now)
+}
+
+// resourceHoursEstimate is the dimensionless fallback cost (cpu × memGB ×
+// hours) used when an attempt has no real cost data.
+func resourceHoursEstimate(call Call, now time.Time) float64 {
+	cpu := parseCPUFromString(call.CPU)
+	if cpu <= 0 {
+		cpu = 1
+	}
+	mem := parseMemoryGBFromString(call.Memory)
+	if mem <= 0 {
+		mem = 1
+	}
+
+	durationHours := billableHours(call, now)
+	if durationHours <= 0 {
+		durationHours = 0.01 // Minimum 36 seconds
+	}
+
+	return cpu * mem * durationHours
 }

--- a/internal/domain/workflow/cost_test.go
+++ b/internal/domain/workflow/cost_test.go
@@ -36,7 +36,7 @@ func TestCalculateCostBreakdownAggregatesAndSorts(t *testing.T) {
 	if b.Tasks[0].Name != "Merge" {
 		t.Errorf("expected Merge first (most expensive), got %s", b.Tasks[0].Name)
 	}
-	if got := b.Tasks[0].TotalCost; got < 1.99 || got > 2.01 {
+	if got := b.Tasks[0].ActualCost; got < 1.99 || got > 2.01 {
 		t.Errorf("Merge cost = %.3f, want ~2.00", got)
 	}
 	if b.Tasks[0].Preemptible {
@@ -48,14 +48,14 @@ func TestCalculateCostBreakdownAggregatesAndSorts(t *testing.T) {
 	if !b.Tasks[1].Preemptible {
 		t.Errorf("Collect should be preemptible")
 	}
-	if total := b.TotalCost; total < 2.19 || total > 2.21 {
-		t.Errorf("total = %.3f, want ~2.20", total)
+	if total := b.ActualTotal; total < 2.19 || total > 2.21 {
+		t.Errorf("actual total = %.3f, want ~2.20", total)
 	}
 	if p := b.Tasks[0].Percent; p < 90 || p > 91 {
 		t.Errorf("Merge percent = %.1f, want ~90.9", p)
 	}
-	if !b.FromActual {
-		t.Errorf("expected FromActual true when all costs use vmCostPerHour")
+	if b.HasEstimates() {
+		t.Errorf("no estimates expected when every attempt has vmCostPerHour, got %v", b.EstimatedTotal)
 	}
 }
 
@@ -147,13 +147,79 @@ func TestCalculateCostBreakdownIncludesRunningTasks(t *testing.T) {
 		t.Fatalf("expected 1 task, got %+v", b.Tasks)
 	}
 	got := b.Tasks[0]
-	if got.TotalCost < 0.19 || got.TotalCost > 0.21 {
-		t.Errorf("running task cost = %v, want ≈0.20 (0.10/h × 2h accrued)", got.TotalCost)
+	if got.ActualCost < 0.19 || got.ActualCost > 0.21 {
+		t.Errorf("running task cost = %v, want ≈0.20 (0.10/h × 2h accrued)", got.ActualCost)
 	}
 	if got.VMHours < 1.9 || got.VMHours > 2.1 {
 		t.Errorf("running task VMHours = %v, want ≈2", got.VMHours)
 	}
-	if !got.FromActual {
-		t.Errorf("cost from real vmCostPerHour should be FromActual")
+	if got.EstimatedCost != 0 {
+		t.Errorf("cost from real vmCostPerHour should not produce an estimate, got %v", got.EstimatedCost)
+	}
+}
+
+func TestCalculateCostBreakdownKeepsActualAndEstimateApart(t *testing.T) {
+	s1, e1 := hoursApart("2026-07-06T06:00:00Z", 10)
+	s2, e2 := hoursApart("2026-07-06T06:00:00Z", 2)
+
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			// Real cost: 10h × $0.20 = $2.00
+			"WF.Priced": {{Name: "WF.Priced", ShardIndex: -1, Attempt: 1, Start: s1, End: e1, VMCostPerHour: 0.20, Preemptible: "false"}},
+			// No vmCostPerHour: falls back to 4 cpu × 8 GB × 2h = 64 resource-hours
+			"WF.Unpriced": {{Name: "WF.Unpriced", ShardIndex: -1, Attempt: 1, Start: s2, End: e2, CPU: "4", Memory: "8 GB", Preemptible: "true"}},
+		},
+	}
+
+	b := wf.CalculateCostBreakdown()
+
+	if b.ActualTotal < 1.99 || b.ActualTotal > 2.01 {
+		t.Errorf("actual total = %v, want ~2.00 — the 64 resource-hours estimate must not leak into dollars", b.ActualTotal)
+	}
+	if b.EstimatedTotal < 63.9 || b.EstimatedTotal > 64.1 {
+		t.Errorf("estimated total = %v, want ~64 resource-hours", b.EstimatedTotal)
+	}
+	if !b.HasEstimates() {
+		t.Errorf("HasEstimates should be true when an attempt lacks cost data")
+	}
+
+	// The priced task sorts first even though 64 > 2 numerically: units are
+	// not comparable, dollars lead.
+	if b.Tasks[0].Name != "Priced" {
+		t.Fatalf("expected Priced first, got %s", b.Tasks[0].Name)
+	}
+	// Percent is a share of the dollar total only: the priced task owns 100%
+	// and the estimate-only task has no dollar share.
+	if p := b.Tasks[0].Percent; p < 99.9 || p > 100.1 {
+		t.Errorf("Priced percent = %v, want 100 (share of dollars only)", p)
+	}
+	if p := b.Tasks[1].Percent; p != 0 {
+		t.Errorf("Unpriced percent = %v, want 0 (it has no dollar cost)", p)
+	}
+}
+
+func TestCalculateCostBreakdownPercentFallsBackToEstimates(t *testing.T) {
+	s1, e1 := hoursApart("2026-07-06T06:00:00Z", 3)
+	s2, e2 := hoursApart("2026-07-06T06:00:00Z", 1)
+
+	// A backend that reports no cost at all: percentages come from the
+	// estimates so relative weights are still meaningful.
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.Big":   {{Name: "WF.Big", ShardIndex: -1, Attempt: 1, Start: s1, End: e1, CPU: "1", Memory: "1 GB"}},
+			"WF.Small": {{Name: "WF.Small", ShardIndex: -1, Attempt: 1, Start: s2, End: e2, CPU: "1", Memory: "1 GB"}},
+		},
+	}
+
+	b := wf.CalculateCostBreakdown()
+
+	if b.ActualTotal != 0 {
+		t.Fatalf("actual total = %v, want 0", b.ActualTotal)
+	}
+	if b.Tasks[0].Name != "Big" {
+		t.Fatalf("expected Big first, got %s", b.Tasks[0].Name)
+	}
+	if p := b.Tasks[0].Percent; p < 74.9 || p > 75.1 {
+		t.Errorf("Big percent = %v, want ~75 (3 of 4 resource-hours)", p)
 	}
 }

--- a/internal/domain/workflow/preemption.go
+++ b/internal/domain/workflow/preemption.go
@@ -290,30 +290,12 @@ func windowHours(start, end time.Time, status Status, now time.Time) float64 {
 }
 
 // calculateAttemptCost calculates the estimated cost of a single attempt.
+// Note: the preemption summary intentionally blends real dollars and
+// resource-hours into a single relative number (see PreemptionSummary.CostUnit);
+// the cost breakdown keeps the two units apart via attemptCostParts.
 func calculateAttemptCost(call Call, now time.Time) float64 {
-	// If we have actual VM cost per hour, use it against the billed VM lifetime
-	if call.VMCostPerHour > 0 {
-		if hours := billableHours(call, now); hours > 0 {
-			return call.VMCostPerHour * hours
-		}
-	}
-
-	// Otherwise, estimate using resource-hours
-	cpu := parseCPUFromString(call.CPU)
-	if cpu <= 0 {
-		cpu = 1
-	}
-	mem := parseMemoryGBFromString(call.Memory)
-	if mem <= 0 {
-		mem = 1
-	}
-
-	durationHours := billableHours(call, now)
-	if durationHours <= 0 {
-		durationHours = 0.01 // Minimum 36 seconds
-	}
-
-	return cpu * mem * durationHours
+	actual, estimated := attemptCostParts(call, now)
+	return actual + estimated
 }
 
 // IsPreemptible checks if a task is configured as preemptible.

--- a/internal/infrastructure/cromwell/cost_validation_test.go
+++ b/internal/infrastructure/cromwell/cost_validation_test.go
@@ -31,13 +31,13 @@ func TestCostBreakdownMatchesAPI(t *testing.T) {
 	}
 
 	b := wf.CalculateCostBreakdown()
-	t.Logf("reconstructed total: $%.4f across %d tasks (pending subs: %d)",
-		b.TotalCost, len(b.Tasks), b.SubworkflowsPending)
+	t.Logf("reconstructed actual total: $%.4f (+ ~%.1f resource-hours estimated) across %d tasks (pending subs: %d)",
+		b.ActualTotal, b.EstimatedTotal, len(b.Tasks), b.SubworkflowsPending)
 	for i, tc := range b.Tasks {
 		if i >= 5 {
 			break
 		}
-		t.Logf("  %-40s $%.2f (%.1f%%, %.1fh, preempt=%v)", tc.Name, tc.TotalCost, tc.Percent, tc.VMHours, tc.Preemptible)
+		t.Logf("  %-40s $%.2f (~%.1frh, %.1f%%, %.1fh, preempt=%v)", tc.Name, tc.ActualCost, tc.EstimatedCost, tc.Percent, tc.VMHours, tc.Preemptible)
 	}
 
 	expected := os.Getenv("PUMBAA_COST_EXPECTED")
@@ -48,13 +48,15 @@ func TestCostBreakdownMatchesAPI(t *testing.T) {
 	if _, err := fmt.Sscanf(expected, "%g", &want); err != nil {
 		t.Fatalf("bad PUMBAA_COST_EXPECTED: %v", err)
 	}
+	// Only real dollars are comparable to the API total; the resource-hours
+	// estimate is a different unit and stays out of the check.
 	// Allow 2% drift: our estimate uses call Start/End while Cromwell's cost
 	// may use slightly different VM lifetime boundaries.
-	diff := b.TotalCost - want
+	diff := b.ActualTotal - want
 	if diff < 0 {
 		diff = -diff
 	}
 	if want > 0 && diff/want > 0.02 {
-		t.Errorf("reconstructed $%.4f differs from API $%.4f by %.1f%% (>2%%)", b.TotalCost, want, 100*diff/want)
+		t.Errorf("reconstructed $%.4f differs from API $%.4f by %.1f%% (>2%%)", b.ActualTotal, want, 100*diff/want)
 	}
 }

--- a/internal/interfaces/tui/debug/modal_cost.go
+++ b/internal/interfaces/tui/debug/modal_cost.go
@@ -120,12 +120,21 @@ func (m Model) buildCostContent() string {
 		sb.WriteString(costBadgeStyle.Render(fmt.Sprintf("$%.2f", m.totalCost)))
 		sb.WriteString("\n")
 	}
-	sb.WriteString(mutedStyle.Render(fmt.Sprintf("Accounted here: $%.2f across %d task(s)",
-		breakdown.TotalCost, len(breakdown.Tasks))))
-	if !breakdown.FromActual {
-		sb.WriteString(mutedStyle.Render("  (some values estimated from resources)"))
+	if breakdown.ActualTotal > 0 {
+		sb.WriteString(mutedStyle.Render(fmt.Sprintf("Accounted here: $%.2f across %d task(s)",
+			breakdown.ActualTotal, len(breakdown.Tasks))))
+		sb.WriteString("\n")
 	}
-	sb.WriteString("\n")
+	if breakdown.HasEstimates() {
+		estimated := fmt.Sprintf("~%.1f", breakdown.EstimatedTotal)
+		if breakdown.EstimatedTotal < 0.1 {
+			estimated = "<0.1"
+		}
+		sb.WriteString(mutedStyle.Render(fmt.Sprintf(
+			"No cost data for some attempts: %s resource-hours estimated (marked ~, not added to $)",
+			estimated)))
+		sb.WriteString("\n")
+	}
 	switch {
 	case m.costLoading:
 		sb.WriteString(infoNoteStyle.Render("⏳ Loading subworkflow costs — totals will update shortly..."))
@@ -152,10 +161,20 @@ func (m Model) buildCostContent() string {
 		maxNameLen = 44
 	}
 
-	maxCost := breakdown.Tasks[0].TotalCost // sorted desc
+	// Bars are scaled within each unit: dollar rows against the biggest
+	// dollar value, estimate-only rows against the biggest estimate.
+	var maxActual, maxEstimated float64
+	for _, t := range breakdown.Tasks {
+		if t.ActualCost > maxActual {
+			maxActual = t.ActualCost
+		}
+		if t.EstimatedCost > maxEstimated {
+			maxEstimated = t.EstimatedCost
+		}
+	}
 
 	for _, t := range breakdown.Tasks {
-		sb.WriteString(m.formatCostRow(t, maxNameLen, maxCost))
+		sb.WriteString(m.formatCostRow(t, maxNameLen, maxActual, maxEstimated))
 		sb.WriteString("\n")
 	}
 
@@ -169,17 +188,30 @@ func (m Model) buildCostContent() string {
 	return sb.String()
 }
 
-func (m Model) formatCostRow(t workflow.TaskCost, maxNameLen int, maxCost float64) string {
+func (m Model) formatCostRow(t workflow.TaskCost, maxNameLen int, maxActual, maxEstimated float64) string {
 	name := common.PadRight(t.Name, maxNameLen)
 
-	cost := fmt.Sprintf("$%7.2f", t.TotalCost)
+	// A task is shown in the unit it has data for: real dollars, or the
+	// resource-hours estimate (marked with ~) when no attempt reported cost.
+	// Tasks with dollars AND an estimated remainder keep the ~ as a hint.
+	var cost string
+	value, maxValue := t.ActualCost, maxActual
+	switch {
+	case t.ActualCost > 0 && t.EstimatedCost > 0:
+		cost = fmt.Sprintf("$%6.2f~", t.ActualCost)
+	case t.ActualCost > 0:
+		cost = fmt.Sprintf("$%6.2f ", t.ActualCost)
+	default:
+		cost = fmt.Sprintf("~%5.1frh", t.EstimatedCost)
+		value, maxValue = t.EstimatedCost, maxEstimated
+	}
 	pct := fmt.Sprintf("%5.1f%%", t.Percent)
 
-	// Cost bar proportional to the most expensive task
+	// Cost bar proportional to the most expensive task in the same unit
 	barWidth := 20
 	filled := 0
-	if maxCost > 0 {
-		filled = int(t.TotalCost / maxCost * float64(barWidth))
+	if maxValue > 0 {
+		filled = int(value / maxValue * float64(barWidth))
 	}
 	if filled > barWidth {
 		filled = barWidth


### PR DESCRIPTION
## Context and problem

The cost-by-task modal reconstructs per-task costs from workflow metadata. When an attempt reports a real hourly VM rate, its cost is genuine dollars; when it doesn't (backends that report no cost, or attempts with no usable timestamps), the code falls back to a resource-based estimate — CPU × memory × hours, a dimensionless "resource-hours" number.

Until now both were summed into a single total displayed with a dollar sign. A small disclaimer ("some values estimated from resources") acknowledged the mix, but the number itself was misleading: on a backend that reports no cost at all, the entire total was fiction with a `$` in front of it, and on mixed workflows the estimates polluted the real figure. This was flagged as the top follow-up in the improvement backlog after the recent fix for running-task cost accrual, which was an extreme symptom of the same unit mixing.

## What was done

- The domain cost breakdown now keeps the two units apart end to end: the workflow-level result carries an actual total (dollars) and an estimated total (resource-hours) as separate figures, and each task splits its actual cost from its estimated cost. Exactly one of the two is produced per attempt, so nothing is ever double-counted or blended.
- Percentages are now shares within a single unit. When the workflow has any real dollars, each task's share is computed over the dollar total (estimate-only tasks show no share); when there are none, shares fall back to the estimates so relative weights remain meaningful on cost-less backends.
- Sorting puts dollar-bearing tasks first (by dollars), then estimate-only tasks (by estimate) — the units are not numerically comparable, so a large estimate no longer outranks real spend.
- The modal renders the split: the header shows the dollar total and, when applicable, a separate line for the estimated resource-hours; estimate-only rows display a `~` prefixed value in resource-hours instead of a fake dollar figure; progress bars are scaled within each unit so they stay proportional.
- The opt-in validation test that compares the reconstruction against Cromwell's cost endpoint now checks only the dollar total — the portion that is actually comparable to the API.

## Decisions and rationale

- **Two fields instead of a unified "confidence-weighted" number.** Any scheme that folds the estimate into a dollar figure re-creates the original problem. Keeping the units separate is the only honest representation, and the UI copes fine with two lines.
- **The resource-hours estimate stays.** It is still useful as a relative weight when no cost data exists (which backend-less local runs produce), so it was kept — visible, labeled, and out of the dollar arithmetic.
- **The preemption summary was intentionally left blending units.** It reports relative efficiency, already labels its unit explicitly, and reworking it was out of scope; the shared attempt-cost helper now documents this distinction.

## Impacts and risks

- User-visible change in the cost modal: totals no longer inflate when estimates exist, estimate rows show `~Nrh` instead of `$N`, and percentages are dollar-shares. Anyone who relied on the old mixed total will see different (smaller, correct) numbers.
- Domain type change: the breakdown's mixed total and per-task "from actual" flag were replaced by the explicit actual/estimated pair. All consumers live in this repository and were updated.

## How to validate

- Full test suite passes. New domain tests cover: estimates never leaking into the dollar total, dollar-first sorting across units, dollar-share percentages, and the estimate-based percentage fallback for workflows with no cost data.
- Replayed a saved expanded-metadata file from a real running workflow with subworkflows through the actual parsing pipeline: the dollar total tracks Cromwell's cost API figure, with a residual sub-0.1 resource-hours estimate correctly reported for a queued attempt instead of being silently added to the dollars.
- The opt-in API validation test (`PUMBAA_COST_VALIDATE` / `PUMBAA_COST_EXPECTED`) remains available for checking against a live workflow.
