### PR TITLE
fix(domain): scope shard aggregation by subworkflow instance

### DIFF
--- a/internal/domain/workflow/cost.go
+++ b/internal/domain/workflow/cost.go
@@ -5,6 +5,7 @@ package workflow
 
 import (
 	"sort"
+	"strconv"
 	"time"
 )
 
@@ -40,7 +41,7 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 	type agg struct {
 		cost       float64
 		vmHours    float64
-		shards     map[int]bool
+		shards     map[string]bool
 		attempts   int
 		preempt    bool
 		fromActual bool
@@ -53,13 +54,17 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 	// cost up to this instant.
 	now := time.Now()
 
-	var walk func(calls map[string][]Call)
-	walk = func(calls map[string][]Call) {
+	// scope identifies the (sub)workflow instance a call belongs to, so that
+	// shards of same-named tasks in different subworkflow instances are not
+	// collapsed together (a scattered subworkflow runs the same task many
+	// times, each at shard -1 of its own instance).
+	var walk func(calls map[string][]Call, scope string)
+	walk = func(calls map[string][]Call, scope string) {
 		for callName, callList := range calls {
 			short := preemptionShortTaskName(callName)
 			for _, call := range callList {
 				if call.SubWorkflowMetadata != nil {
-					walk(call.SubWorkflowMetadata.Calls)
+					walk(call.SubWorkflowMetadata.Calls, subworkflowScope(scope, callName, call.ShardIndex))
 					continue
 				}
 				if call.SubWorkflowID != "" {
@@ -70,14 +75,14 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 
 				a := aggregations[short]
 				if a == nil {
-					a = &agg{shards: make(map[int]bool), allActual: true}
+					a = &agg{shards: make(map[string]bool), allActual: true}
 					aggregations[short] = a
 					order = append(order, short)
 				}
 				cost := calculateAttemptCost(call, now)
 				a.cost += cost
 				a.attempts++
-				a.shards[call.ShardIndex] = true
+				a.shards[scope+strconv.Itoa(call.ShardIndex)] = true
 				if IsPreemptible(call.Preemptible) {
 					a.preempt = true
 				}
@@ -90,7 +95,7 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 			}
 		}
 	}
-	walk(w.Calls)
+	walk(w.Calls, "")
 
 	breakdown := &CostBreakdown{
 		FromActual:          true,
@@ -124,4 +129,11 @@ func (w *Workflow) CalculateCostBreakdown() *CostBreakdown {
 	})
 
 	return breakdown
+}
+
+// subworkflowScope extends a scope with one subworkflow call instance —
+// name plus the call's own shard index, so each element of a scattered
+// subworkflow is a distinct instance.
+func subworkflowScope(scope, callName string, shardIndex int) string {
+	return scope + callName + "#" + strconv.Itoa(shardIndex) + "/"
 }

--- a/internal/domain/workflow/cost_test.go
+++ b/internal/domain/workflow/cost_test.go
@@ -157,3 +157,39 @@ func TestCalculateCostBreakdownIncludesRunningTasks(t *testing.T) {
 		t.Errorf("cost from real vmCostPerHour should be FromActual")
 	}
 }
+
+func TestCalculateCostBreakdownCountsShardsPerSubworkflowInstance(t *testing.T) {
+	s, e := hoursApart("2026-07-06T06:00:00Z", 1)
+
+	// Two instances of the same scattered subworkflow, each running Inner at
+	// shard -1 of its own instance. They are distinct executions and must
+	// count as distinct shards, not collapse into one.
+	makeSub := func() *Workflow {
+		return &Workflow{
+			Calls: map[string][]Call{
+				"Sub.Inner": {{Name: "Sub.Inner", ShardIndex: -1, Attempt: 1, Start: s, End: e, VMCostPerHour: 0.10, Preemptible: "true"}},
+			},
+		}
+	}
+
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.Scattered": {
+				{Name: "WF.Scattered", ShardIndex: 0, SubWorkflowID: "sub-a", SubWorkflowMetadata: makeSub()},
+				{Name: "WF.Scattered", ShardIndex: 1, SubWorkflowID: "sub-b", SubWorkflowMetadata: makeSub()},
+			},
+		},
+	}
+
+	b := wf.CalculateCostBreakdown()
+
+	if len(b.Tasks) != 1 || b.Tasks[0].Name != "Inner" {
+		t.Fatalf("expected one aggregated Inner task, got %+v", b.Tasks)
+	}
+	if b.Tasks[0].ShardCount != 2 {
+		t.Errorf("ShardCount = %d, want 2 (one per subworkflow instance)", b.Tasks[0].ShardCount)
+	}
+	if b.Tasks[0].AttemptCount != 2 {
+		t.Errorf("AttemptCount = %d, want 2", b.Tasks[0].AttemptCount)
+	}
+}

--- a/internal/domain/workflow/preemption.go
+++ b/internal/domain/workflow/preemption.go
@@ -93,50 +93,65 @@ func (w *Workflow) CalculatePreemptionSummary() *PreemptionSummary {
 	}
 	taskAggregations := make(map[string]*taskAggregation)
 
-	for callName, callList := range w.Calls {
-		// Group by shard index to calculate per-shard stats
-		shardGroups := make(map[int][]Call)
-		for _, call := range callList {
-			shardGroups[call.ShardIndex] = append(shardGroups[call.ShardIndex], call)
-		}
-
-		for shardIndex, attempts := range shardGroups {
-			key := taskKey{name: callName, shard: shardIndex}
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-
-			stats := analyzeTaskShard(attempts, now)
-			summary.TotalTasks++
-
-			if stats.IsPreemptible {
-				summary.PreemptibleTasks++
-				summary.TotalAttempts += stats.TotalAttempts
-				summary.TotalPreemptions += stats.PreemptedCount
-				totalEfficiency += stats.EfficiencyScore
-				preemptibleCount++
-
-				// Accumulate cost metrics
-				summary.TotalCost += stats.TotalCost
-				summary.WastedCost += stats.WastedCost
-
-				// Aggregate by short task name
-				taskName := preemptionShortTaskName(callName)
-				if taskAggregations[taskName] == nil {
-					taskAggregations[taskName] = &taskAggregation{}
+	// scope identifies the (sub)workflow instance, so same-named task shards
+	// from different subworkflow instances are analyzed as separate attempt
+	// chains instead of being collapsed together.
+	var walk func(calls map[string][]Call, scope string)
+	walk = func(calls map[string][]Call, scope string) {
+		for callName, callList := range calls {
+			// Group by shard index to calculate per-shard stats
+			shardGroups := make(map[int][]Call)
+			for _, call := range callList {
+				if call.SubWorkflowMetadata != nil {
+					walk(call.SubWorkflowMetadata.Calls, subworkflowScope(scope, callName, call.ShardIndex))
+					continue
 				}
-				agg := taskAggregations[taskName]
-				agg.shardCount++
-				agg.totalAttempts += stats.TotalAttempts
-				agg.totalPreemptions += stats.PreemptedCount
-				agg.totalEfficiency += stats.EfficiencyScore
-				agg.shardsCounted++
-				agg.totalCost += stats.TotalCost
-				agg.wastedCost += stats.WastedCost
+				if call.SubWorkflowID != "" {
+					// Subworkflow not loaded: its tasks are absent from this summary.
+					continue
+				}
+				shardGroups[call.ShardIndex] = append(shardGroups[call.ShardIndex], call)
+			}
+
+			for shardIndex, attempts := range shardGroups {
+				key := taskKey{name: scope + callName, shard: shardIndex}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+
+				stats := analyzeTaskShard(attempts, now)
+				summary.TotalTasks++
+
+				if stats.IsPreemptible {
+					summary.PreemptibleTasks++
+					summary.TotalAttempts += stats.TotalAttempts
+					summary.TotalPreemptions += stats.PreemptedCount
+					totalEfficiency += stats.EfficiencyScore
+					preemptibleCount++
+
+					// Accumulate cost metrics
+					summary.TotalCost += stats.TotalCost
+					summary.WastedCost += stats.WastedCost
+
+					// Aggregate by short task name
+					taskName := preemptionShortTaskName(callName)
+					if taskAggregations[taskName] == nil {
+						taskAggregations[taskName] = &taskAggregation{}
+					}
+					agg := taskAggregations[taskName]
+					agg.shardCount++
+					agg.totalAttempts += stats.TotalAttempts
+					agg.totalPreemptions += stats.PreemptedCount
+					agg.totalEfficiency += stats.EfficiencyScore
+					agg.shardsCounted++
+					agg.totalCost += stats.TotalCost
+					agg.wastedCost += stats.WastedCost
+				}
 			}
 		}
 	}
+	walk(w.Calls, "")
 
 	// Calculate workflow-level cost efficiency
 	if summary.TotalCost > 0 {

--- a/internal/domain/workflow/preemption_test.go
+++ b/internal/domain/workflow/preemption_test.go
@@ -318,3 +318,44 @@ func TestParseMemoryGBFromString(t *testing.T) {
 		})
 	}
 }
+
+func TestPreemptionSummaryRecursesIntoLoadedSubworkflows(t *testing.T) {
+	s1, e1 := hoursApart("2026-07-06T06:00:00Z", 1)
+	s2, e2 := hoursApart("2026-07-06T07:30:00Z", 1)
+
+	// A preempted-then-succeeded chain inside a loaded subworkflow: attempt 1
+	// preempted (RetryableFailure), attempt 2 done.
+	makeSub := func() *Workflow {
+		return &Workflow{
+			Calls: map[string][]Call{
+				"Sub.Inner": {
+					{Name: "Sub.Inner", ShardIndex: -1, Attempt: 1, Status: "RetryableFailure", Start: s1, End: e1, VMCostPerHour: 0.10, Preemptible: "2"},
+					{Name: "Sub.Inner", ShardIndex: -1, Attempt: 2, Status: "Done", Start: s2, End: e2, VMCostPerHour: 0.10, Preemptible: "2"},
+				},
+			},
+		}
+	}
+
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.SubA":    {{Name: "WF.SubA", ShardIndex: 0, SubWorkflowID: "sub-a", SubWorkflowMetadata: makeSub()}},
+			"WF.SubB":    {{Name: "WF.SubB", ShardIndex: 1, SubWorkflowID: "sub-b", SubWorkflowMetadata: makeSub()}},
+			"WF.Pending": {{Name: "WF.Pending", SubWorkflowID: "sub-c"}}, // not loaded
+		},
+	}
+
+	sum := wf.CalculatePreemptionSummary()
+
+	// Two instances × one task/shard chain each. Before recursion existed,
+	// subworkflow tasks were invisible here (TotalTasks counted the wrapper
+	// calls instead).
+	if sum.TotalTasks != 2 {
+		t.Errorf("TotalTasks = %d, want 2 (one chain per subworkflow instance)", sum.TotalTasks)
+	}
+	if sum.TotalAttempts != 4 {
+		t.Errorf("TotalAttempts = %d, want 4", sum.TotalAttempts)
+	}
+	if sum.TotalPreemptions != 2 {
+		t.Errorf("TotalPreemptions = %d, want 2 (one per instance — chains must not merge)", sum.TotalPreemptions)
+	}
+}


### PR DESCRIPTION
## Context and problem

Two aggregations in the workflow domain treat "task shard" as globally unique, but in workflows that scatter subworkflows the same task runs once per subworkflow instance — each execution at shard -1 of its own instance:

- The per-task cost breakdown keyed shards by shard index alone, so all those executions collapsed into one: on a real training workflow, a task with 59 executions displayed "×2" in the cost modal, understating parallelism and making the hours column impossible to interpret.
- The preemption summary was worse: it never descended into loaded subworkflow metadata at all. On subworkflow-heavy runs it analyzed only the wrapper calls — which have no attempts of their own — and reported essentially nothing, while unloaded subworkflow calls were miscounted as tasks.

This was item 2 of the improvement backlog, noted as a known limitation during the recent running-cost fix.

## What was done

- The cost breakdown's recursive walk now carries an instance scope (the chain of subworkflow call names and their scatter indices) and keys shards by scope plus shard index. Same-named tasks still aggregate into one row per task — as intended for the "where does the money go" view — but the shard count now reflects distinct executions.
- The preemption summary gained the same recursive walk: tasks inside loaded subworkflows are analyzed, retry chains from different instances are kept separate (so preemption counts cannot bleed across instances), and subworkflow wrapper calls — loaded or pending — are no longer counted as tasks themselves.

## Decisions and rationale

- **Aggregation by task name was preserved.** The breakdown intentionally answers "which task costs the most overall"; keying rows by instance would fragment that view. Only the shard-uniqueness bookkeeping needed instance awareness.
- **Unloaded subworkflows are skipped, not guessed.** The cost view already reports how many subworkflows are missing; the preemption summary now simply omits them, consistent with analyzing only what is loaded.

## Impacts and risks

- Shard counts in the cost modal grow to their true values on scattered-subworkflow runs (e.g. "×2" becomes "×59"); attempts and costs are unchanged.
- The preemption summary shown in the debug view changes meaningfully on subworkflow-heavy workflows: it now includes the real tasks, so totals, attempt counts and efficiency reflect the whole run instead of the top level only. Flat workflows are unaffected.
- Merge note: this branch and the cost-units branch (#46) touch the same aggregation function; whichever merges second needs a trivial rebase.

## How to validate

- Full test suite passes. New tests cover: two instances of the same scattered subworkflow counting as two shards in the cost breakdown, and the preemption summary recursing into subworkflow instances while keeping their retry chains separate.
- Replayed the saved expanded metadata of a real running workflow (multiple subworkflow instances): shard counts now match the actual execution counts per task, and the preemption summary sees all 317 task chains where it previously saw only wrapper calls.
