### PR TITLE
test(tui): cover the chat screen's agent loop, update flow and sessions

### DIFF
--- a/internal/interfaces/tui/chat/helpers_test.go
+++ b/internal/interfaces/tui/chat/helpers_test.go
@@ -1,0 +1,86 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+)
+
+func TestExtractText(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			genai.NewPartFromText("hello"),
+			genai.NewPartFromText("world"),
+		},
+	}
+	// Multiple text parts are joined with newlines.
+	if got := extractText(content); got != "hello\nworld" {
+		t.Errorf("extractText = %q, want %q", got, "hello\nworld")
+	}
+
+	empty := &genai.Content{Role: "model"}
+	if got := extractText(empty); got != "" {
+		t.Errorf("extractText on empty content = %q, want empty", got)
+	}
+}
+
+func TestWrapText(t *testing.T) {
+	if got := wrapText("short", 10); got != "short" {
+		t.Errorf("short line should be untouched, got %q", got)
+	}
+
+	got := wrapText("aaa bbb ccc", 7)
+	for _, line := range strings.Split(got, "\n") {
+		if len(line) > 7 {
+			t.Errorf("line %q exceeds width 7", line)
+		}
+	}
+
+	// A word longer than the width is force-broken instead of looping forever.
+	got = wrapText(strings.Repeat("x", 25), 10)
+	if lines := strings.Split(got, "\n"); len(lines) != 3 {
+		t.Errorf("expected forced break into 3 lines, got %d: %q", len(lines), got)
+	}
+
+	// Zero width falls back to the default instead of panicking.
+	if got := wrapText("abc", 0); got != "abc" {
+		t.Errorf("zero width should fall back to default, got %q", got)
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{5 * time.Minute, "5m ago"},
+		{3 * time.Hour, "3h ago"},
+		{49 * time.Hour, "2d ago"},
+	}
+	for _, c := range cases {
+		if got := formatAge(c.d); got != c.want {
+			t.Errorf("formatAge(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func TestFormatTokenCount(t *testing.T) {
+	cases := []struct {
+		count int
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1500, "1.5K"},
+		{2300000, "2.3M"},
+	}
+	for _, c := range cases {
+		if got := formatTokenCount(c.count); got != c.want {
+			t.Errorf("formatTokenCount(%d) = %q, want %q", c.count, got, c.want)
+		}
+	}
+}

--- a/internal/interfaces/tui/chat/sessions_test.go
+++ b/internal/interfaces/tui/chat/sessions_test.go
@@ -1,0 +1,108 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/adk/session"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+)
+
+// fakeStore wraps the ADK in-memory session service with the pumbaa-specific
+// queries of ports.ChatSessionStore, recording what was written.
+type fakeStore struct {
+	session.Service
+	latest *ports.ChatSessionInfo
+	labels map[string]string
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{Service: session.InMemoryService(), labels: map[string]string{}}
+}
+
+func (f *fakeStore) ListWithSummaries(ctx context.Context, appName, userID string) ([]ports.ChatSessionInfo, error) {
+	if f.latest == nil {
+		return nil, nil
+	}
+	return []ports.ChatSessionInfo{*f.latest}, nil
+}
+
+func (f *fakeStore) FindLatestByContextLabel(ctx context.Context, appName, userID, label string) (*ports.ChatSessionInfo, error) {
+	return f.latest, nil
+}
+
+func (f *fakeStore) SetContextLabel(ctx context.Context, sessionID, label string) error {
+	f.labels[sessionID] = label
+	return nil
+}
+
+func (f *fakeStore) UpdateSummary(ctx context.Context, sessionID, summary string) error { return nil }
+
+func (f *fakeStore) UpdateTokenUsage(ctx context.Context, sessionID string, inputTokens, outputTokens int) error {
+	return nil
+}
+
+func (f *fakeStore) Close() error { return nil }
+
+func TestFindResumableCmdRequiresContext(t *testing.T) {
+	store := newFakeStore()
+	store.latest = &ports.ChatSessionInfo{ID: "sess-9"}
+
+	// Without a context label there is nothing to resume by.
+	m := newTestModel(t, store)
+	if cmd := m.findResumableCmd(); cmd != nil {
+		t.Errorf("no context label: expected nil cmd")
+	}
+
+	// A plain ADK service without the extended queries cannot resume.
+	m2 := newTestModel(t, session.InMemoryService())
+	m2.SetContextLabel("wf ▸ task")
+	if cmd := m2.findResumableCmd(); cmd != nil {
+		t.Errorf("service without ChatSessionStore: expected nil cmd")
+	}
+}
+
+func TestFindResumableCmdReportsPreviousSession(t *testing.T) {
+	store := newFakeStore()
+	store.latest = &ports.ChatSessionInfo{ID: "sess-9", Summary: "old chat"}
+
+	m := newTestModel(t, store)
+	m.SetContextLabel("wf ▸ task")
+
+	cmd := m.findResumableCmd()
+	if cmd == nil {
+		t.Fatal("expected a lookup command")
+	}
+	msg, ok := cmd().(resumableFoundMsg)
+	if !ok {
+		t.Fatalf("expected resumableFoundMsg, got %T", cmd())
+	}
+	if msg.info.ID != "sess-9" || msg.owner != m.msgs {
+		t.Errorf("unexpected msg: %+v", msg)
+	}
+}
+
+func TestCreateSessionCmdTagsContextLabel(t *testing.T) {
+	store := newFakeStore()
+	m := newTestModel(t, store)
+	m.SetContextLabel("wf ▸ align")
+
+	cmd := m.createSessionCmd()
+	if cmd == nil {
+		t.Fatal("expected a create command")
+	}
+	msg, ok := cmd().(sessionCreatedMsg)
+	if !ok {
+		t.Fatalf("expected sessionCreatedMsg, got %T", cmd())
+	}
+	if msg.err != nil {
+		t.Fatalf("create failed: %v", msg.err)
+	}
+	if msg.session == nil {
+		t.Fatal("no session returned")
+	}
+	if got := store.labels[msg.session.ID()]; got != "wf ▸ align" {
+		t.Errorf("context label not tagged on the new session, got %q", got)
+	}
+}

--- a/internal/interfaces/tui/chat/stream_test.go
+++ b/internal/interfaces/tui/chat/stream_test.go
@@ -1,0 +1,112 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/genai"
+)
+
+// fakeTool implements tool.Tool and the chat's toolWithDefinition interface,
+// mirroring how the real pumbaa function tool is executed by the agent loop.
+type fakeTool struct {
+	name    string
+	result  map[string]any
+	err     error
+	gotArgs any
+}
+
+func (f *fakeTool) Name() string        { return f.name }
+func (f *fakeTool) Description() string { return "fake" }
+func (f *fakeTool) IsLongRunning() bool { return false }
+
+func (f *fakeTool) Declaration() *genai.FunctionDeclaration {
+	return &genai.FunctionDeclaration{Name: f.name}
+}
+
+func (f *fakeTool) Run(_ tool.Context, args any) (map[string]any, error) {
+	f.gotArgs = args
+	return f.result, f.err
+}
+
+func TestToolFailure(t *testing.T) {
+	if got := toolFailure(nil, errors.New("boom")); got != "boom" {
+		t.Errorf("transport error should win, got %q", got)
+	}
+	if got := toolFailure(map[string]any{"success": false, "error": "bad input"}, nil); got != "bad input" {
+		t.Errorf("handler error should be extracted, got %q", got)
+	}
+	if got := toolFailure(map[string]any{"success": false}, nil); got != "failed" {
+		t.Errorf("failure without message should fall back, got %q", got)
+	}
+	if got := toolFailure(map[string]any{"success": true}, nil); got != "" {
+		t.Errorf("success should be empty, got %q", got)
+	}
+	if got := toolFailure(nil, nil); got != "" {
+		t.Errorf("no result and no error should be empty, got %q", got)
+	}
+}
+
+func TestFormatToolRecord(t *testing.T) {
+	got := formatToolRecord("pumbaa", "query", map[string]any{"status": "Failed", "name": "wf"}, 800*time.Millisecond, "")
+	// Params are sorted by key for a stable transcript.
+	if want := "pumbaa query (name=wf, status=Failed) ✓ 0.8s"; got != want {
+		t.Errorf("formatToolRecord = %q, want %q", got, want)
+	}
+
+	got = formatToolRecord("pumbaa", "logs", nil, 2*time.Second, "workflow not found")
+	if !strings.Contains(got, "✗") || !strings.Contains(got, "workflow not found") {
+		t.Errorf("failure record should carry marker and reason, got %q", got)
+	}
+}
+
+func TestGetToolCalls(t *testing.T) {
+	content := &genai.Content{
+		Parts: []*genai.Part{
+			genai.NewPartFromText("thinking..."),
+			{FunctionCall: &genai.FunctionCall{Name: "pumbaa"}},
+			{FunctionCall: &genai.FunctionCall{Name: "other"}},
+		},
+	}
+	calls := getToolCalls(content)
+	if len(calls) != 2 || calls[0].Name != "pumbaa" || calls[1].Name != "other" {
+		t.Errorf("getToolCalls = %+v, want the two function calls in order", calls)
+	}
+
+	if calls := getToolCalls(&genai.Content{}); calls != nil {
+		t.Errorf("content without calls should yield nil, got %+v", calls)
+	}
+}
+
+func TestConvertToolsToGenAI(t *testing.T) {
+	ft := &fakeTool{name: "pumbaa"}
+	tools := convertToolsToGenAI([]tool.Tool{ft})
+	if len(tools) != 1 || len(tools[0].FunctionDeclarations) != 1 || tools[0].FunctionDeclarations[0].Name != "pumbaa" {
+		t.Errorf("convertToolsToGenAI = %+v, want one declaration named pumbaa", tools)
+	}
+}
+
+func TestExecuteTool(t *testing.T) {
+	ft := &fakeTool{name: "pumbaa", result: map[string]any{"success": true}}
+	m := Model{tools: []tool.Tool{ft}}
+
+	args := map[string]any{"action": "query"}
+	result, err := m.executeTool(context.Background(), &genai.FunctionCall{Name: "pumbaa", Args: args})
+	if err != nil {
+		t.Fatalf("executeTool returned error: %v", err)
+	}
+	if success, _ := result["success"].(bool); !success {
+		t.Errorf("expected the fake tool's result, got %+v", result)
+	}
+	if got, ok := ft.gotArgs.(map[string]any); !ok || got["action"] != "query" {
+		t.Errorf("tool should receive the call args, got %+v", ft.gotArgs)
+	}
+
+	if _, err := m.executeTool(context.Background(), &genai.FunctionCall{Name: "unknown"}); err == nil {
+		t.Errorf("unknown tool should return an error")
+	}
+}

--- a/internal/interfaces/tui/chat/update_test.go
+++ b/internal/interfaces/tui/chat/update_test.go
@@ -1,0 +1,286 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+)
+
+// newTestModel builds a chat model with no LLM and an in-memory ADK session
+// service, sized so the viewport is initialized like in a real terminal.
+func newTestModel(t *testing.T, svc session.Service) *Model {
+	t.Helper()
+	m := NewModel(nil, nil, "", svc, nil)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	mp, ok := updated.(*Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want *Model", updated)
+	}
+	return mp
+}
+
+func lastMsg(t *testing.T, m *Model) ChatMessage {
+	t.Helper()
+	if m.msgs == nil || len(*m.msgs) == 0 {
+		t.Fatal("no messages in transcript")
+	}
+	return (*m.msgs)[len(*m.msgs)-1]
+}
+
+func TestSubmitInputStartsGenerationAndLazySession(t *testing.T) {
+	m := newTestModel(t, session.InMemoryService())
+
+	m.textarea.SetValue("what failed?")
+	_, cmd := m.submitInput()
+
+	if !m.loading {
+		t.Errorf("submit should set loading")
+	}
+	if cmd == nil {
+		t.Errorf("submit should return the generation command batch")
+	}
+	if got := lastMsg(t, m); got.Role != "user" || got.Content != "what failed?" {
+		t.Errorf("user message not recorded, got %+v", got)
+	}
+	if m.textarea.Value() != "" {
+		t.Errorf("textarea should be cleared after submit")
+	}
+	if !m.sessionCreating {
+		t.Errorf("first submit should trigger lazy session creation")
+	}
+}
+
+func TestSubmitInputIgnoredWhenEmptyOrLoading(t *testing.T) {
+	m := newTestModel(t, nil)
+
+	m.textarea.SetValue("   ")
+	if _, cmd := m.submitInput(); cmd != nil || m.loading {
+		t.Errorf("blank input must not start a generation")
+	}
+
+	m.loading = true
+	m.textarea.SetValue("hello")
+	if _, cmd := m.submitInput(); cmd != nil {
+		t.Errorf("submit while loading must be a no-op")
+	}
+	if len(*m.msgs) != 0 {
+		t.Errorf("no message should be recorded, got %+v", *m.msgs)
+	}
+}
+
+func TestStreamChunkUpdatesOnlyCurrentConversation(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.loading = true
+
+	m.Update(streamChunkMsg{owner: m.msgs, text: "partial answer"})
+	if m.streamingText != "partial answer" {
+		t.Errorf("streamingText = %q, want the chunk", m.streamingText)
+	}
+
+	other := []ChatMessage{}
+	m.Update(streamChunkMsg{owner: &other, text: "stale"})
+	if m.streamingText != "partial answer" {
+		t.Errorf("a chunk from another conversation must be dropped")
+	}
+
+	m.loading = false
+	m.Update(streamChunkMsg{owner: m.msgs, text: "late"})
+	if m.streamingText != "partial answer" {
+		t.Errorf("chunks after the response landed must be dropped")
+	}
+}
+
+func TestToolRecordAppendsToTranscript(t *testing.T) {
+	m := newTestModel(t, nil)
+
+	m.Update(toolRecordMsg{owner: m.msgs, line: "pumbaa query ✓ 0.3s"})
+	if got := lastMsg(t, m); got.Role != "tool" || got.Content != "pumbaa query ✓ 0.3s" {
+		t.Errorf("tool record not appended, got %+v", got)
+	}
+}
+
+func TestResponseMsgSuccess(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.loading = true
+	m.streamingText = "st"
+	m.focusMode = FocusMessages
+
+	m.Update(ResponseMsg{Content: "final answer", owner: m.msgs, InputTokens: 10, OutputTokens: 5})
+
+	if m.loading {
+		t.Errorf("response should clear loading")
+	}
+	if m.streamingText != "" {
+		t.Errorf("streaming buffer should be cleared")
+	}
+	if got := lastMsg(t, m); got.Role != "agent" || got.Content != "final answer" {
+		t.Errorf("agent message not recorded, got %+v", got)
+	}
+	if m.inputTokens != 10 || m.outputTokens != 5 {
+		t.Errorf("token usage not accumulated: %d/%d", m.inputTokens, m.outputTokens)
+	}
+	if m.focusMode != FocusInput {
+		t.Errorf("focus should return to the input after a response")
+	}
+}
+
+func TestResponseMsgCancelKeepsPartialText(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.loading = true
+	m.streamingText = "partial so far"
+
+	m.Update(ResponseMsg{Err: context.Canceled, owner: m.msgs})
+
+	msgs := *m.msgs
+	if len(msgs) != 2 {
+		t.Fatalf("expected partial + notice, got %+v", msgs)
+	}
+	if msgs[0].Role != "agent" || msgs[0].Content != "partial so far" {
+		t.Errorf("cancelled generation should keep the streamed text, got %+v", msgs[0])
+	}
+	if msgs[1].Role != "notice" {
+		t.Errorf("cancellation should leave a notice, got %+v", msgs[1])
+	}
+}
+
+func TestResponseMsgError(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.loading = true
+
+	m.Update(ResponseMsg{Err: errors.New("LLM unavailable"), owner: m.msgs})
+
+	if got := lastMsg(t, m); got.Role != "error" || got.Content != "LLM unavailable" {
+		t.Errorf("error message not recorded, got %+v", got)
+	}
+}
+
+func TestResponseMsgFromPreviousConversationIsDropped(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.loading = true
+	other := []ChatMessage{}
+
+	m.Update(ResponseMsg{Content: "stale", owner: &other})
+
+	if !m.loading {
+		t.Errorf("a stale response must not end the current generation")
+	}
+	if len(*m.msgs) != 0 {
+		t.Errorf("a stale response must not touch the transcript, got %+v", *m.msgs)
+	}
+}
+
+func TestSessionCreatedAttachesSession(t *testing.T) {
+	svc := session.InMemoryService()
+	m := newTestModel(t, svc)
+	m.sessionCreating = true
+
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{
+		AppName: ports.DefaultChatAppName, UserID: ports.DefaultChatUserID,
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	m.Update(sessionCreatedMsg{owner: m.msgs, session: resp.Session})
+
+	if m.sessionCreating {
+		t.Errorf("creation flag should be cleared")
+	}
+	if m.session == nil || m.session.ID() != resp.Session.ID() {
+		t.Errorf("session not attached")
+	}
+}
+
+func TestSessionCreatedFailureDegradesToNotice(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.sessionCreating = true
+
+	m.Update(sessionCreatedMsg{owner: m.msgs, err: errors.New("disk full")})
+
+	if m.session != nil {
+		t.Errorf("no session should be attached on failure")
+	}
+	if got := lastMsg(t, m); got.Role != "notice" {
+		t.Errorf("failure should degrade to a notice, got %+v", got)
+	}
+}
+
+func TestResumableFoundOffersResume(t *testing.T) {
+	m := newTestModel(t, nil)
+
+	m.Update(resumableFoundMsg{owner: m.msgs, info: ports.ChatSessionInfo{
+		ID: "sess-1", Summary: "debugging align task", EventCount: 4, UpdatedAt: time.Now().Add(-2 * time.Hour),
+	}})
+
+	if m.resumableID != "sess-1" {
+		t.Errorf("resumableID = %q, want sess-1", m.resumableID)
+	}
+	if got := lastMsg(t, m); got.Role != "notice" {
+		t.Errorf("resume offer should be a notice, got %+v", got)
+	}
+}
+
+func TestSessionSwitchedRebuildsTranscript(t *testing.T) {
+	m := newTestModel(t, session.InMemoryService())
+
+	history := []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{genai.NewPartFromText("hi")}},
+		{Role: "model", Parts: []*genai.Part{genai.NewPartFromText("hello!")}},
+	}
+	m.Update(sessionSwitchedMsg{history: history})
+
+	msgs := *m.msgs
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 rebuilt messages, got %+v", msgs)
+	}
+	if msgs[0].Role != "user" || msgs[1].Role != "agent" {
+		t.Errorf("roles not mapped (model→agent), got %+v", msgs)
+	}
+	if msgs[1].Content != "hello!" {
+		t.Errorf("content not extracted, got %+v", msgs[1])
+	}
+}
+
+func TestTabTogglesFocusBetweenInputAndMessages(t *testing.T) {
+	m := newTestModel(t, nil)
+	*m.msgs = append(*m.msgs, ChatMessage{Role: "user", Content: "hi"})
+
+	m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focusMode != FocusMessages {
+		t.Fatalf("first tab should focus messages")
+	}
+	if m.selectedMsg != 0 {
+		t.Errorf("last message should be selected, got %d", m.selectedMsg)
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focusMode != FocusInput {
+		t.Errorf("second tab should return to input")
+	}
+	if m.selectedMsg != -1 {
+		t.Errorf("selection should be cleared, got %d", m.selectedMsg)
+	}
+}
+
+func TestEscDuringGenerationCancels(t *testing.T) {
+	m := newTestModel(t, nil)
+	m.loading = true
+	cancelled := false
+	m.cancelGen = func() { cancelled = true }
+
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !cancelled {
+		t.Errorf("esc during generation should invoke the cancel function")
+	}
+	if !m.loading {
+		t.Errorf("loading only ends when the cancelled response lands")
+	}
+}


### PR DESCRIPTION
## Context and problem

Test coverage is strong in the domain and application layers (89–100%) but thin in the interface layer, and the chat screen had **no tests at all** across roughly 2,100 lines — including the custom agent loop that streams LLM responses and executes tool calls, the most delicate logic in the TUI. Any regression there (a stale message crossing conversations, a cancelled generation losing text, a session attaching twice) would only surface manually. This was item 4 of the improvement backlog, which also noted that the recent restructuring made this cheap: the package is now split into focused files and the session store hides behind a small interface.

## What was done

Four test files were added, targeting the logic that breaks silently rather than visual rendering:

- **Agent-loop building blocks.** The tool-execution path is exercised through the same interface the loop uses at runtime, with a fake tool: dispatch by name, argument pass-through, unknown-tool error. Failure extraction (transport error vs. handler-reported error vs. success), the one-line transcript records (including stable parameter ordering), and the tool-schema conversion are covered.
- **Update flow.** Submitting input starts a generation, records the user message and lazily creates a session exactly once; blank input and submissions during a generation are no-ops. Streaming chunks update the live buffer only for the current conversation and only while loading — chunks and responses from an abandoned conversation are dropped. A landing response covers all three outcomes: success (transcript, token accounting, focus returning to input), cancellation (streamed partial text preserved plus a notice), and error. Session lifecycle messages, transcript rebuilding on session switch, focus toggling and esc-cancels-generation round it out.
- **Session commands.** Resume-by-task requires both a task context and a store that supports the extended queries; the lookup reports the previous session for the right conversation; and new sessions get tagged with the task context label. Tests use the agent framework's real in-memory session service plus a small fake of the store interface.

Package coverage goes from 0% to about 36%, concentrated on state transitions and the agent loop's helpers.

## Decisions and rationale

- **No golden-render tests.** View output depends on terminal styling and would pin cosmetics, not behavior; the value is in the update logic, so that is where the tests went.
- **Real in-memory session service over a hand-rolled mock.** The agent framework ships one; using it keeps the tests honest about the service contract and only the pumbaa-specific store queries are faked.
- **The full generation loop is not driven end-to-end.** It requires a streaming LLM; its seams (tool execution, message handling) are covered instead. Wiring a scripted fake LLM through the loop is a natural follow-up if deeper coverage is wanted.

## Impacts and risks

- Test-only change; no production code was touched.
- The suite runs in milliseconds and needs no network or LLM configured.

## How to validate

- Full test suite passes, including the race detector in CI (the tests exercise the paths that hand off between the generation goroutine and the update loop via messages).
- The new files are clean under the linter, so they will not conflict with the lint-enforcement PR.
