### PR TITLE
refactor: telemetry port, consolidated agent prompts, mapper edge-case tests

### DIFF
--- a/internal/application/ports/telemetry.go
+++ b/internal/application/ports/telemetry.go
@@ -1,0 +1,47 @@
+// Package ports defines the interfaces for external dependencies (repositories, services).
+// This file defines the telemetry sink used by the interface layers.
+package ports
+
+import "time"
+
+// TelemetryEvent represents a tracked user action.
+type TelemetryEvent struct {
+	Command   string
+	Duration  int64 // milliseconds
+	Success   bool
+	Error     string
+	Version   string
+	OS        string
+	Arch      string
+	Timestamp int64
+}
+
+// TelemetryCommandContext holds context for command execution tracking.
+type TelemetryCommandContext struct {
+	AppName   string
+	Args      []string
+	StartTime time.Time
+}
+
+// Telemetry defines the interface for telemetry collection.
+type Telemetry interface {
+	// Track captures an event. It should be non-blocking.
+	Track(event TelemetryEvent)
+
+	// TrackCommand tracks a command execution with automatic event creation.
+	// It handles duration calculation, command name extraction, and error details.
+	TrackCommand(ctx TelemetryCommandContext, err error)
+
+	// CaptureError captures an error with operation context.
+	// Use this for errors that occur outside the normal command flow,
+	// such as errors in TUI interactions or background operations.
+	CaptureError(operation string, err error)
+
+	// AddBreadcrumb logs an event that will appear as context when an error occurs.
+	// Breadcrumbs create a trail of events leading up to an error.
+	// Categories: "app", "navigation", "user", "http", "query"
+	AddBreadcrumb(category, message string)
+
+	// Close flushes any pending events.
+	Close()
+}

--- a/internal/infrastructure/cromwell/mapper_test.go
+++ b/internal/infrastructure/cromwell/mapper_test.go
@@ -270,3 +270,197 @@ func TestParseMemoryGB(t *testing.T) {
 		})
 	}
 }
+
+// TestParseDetailedMetadata_RunningAttempt guards the metadata shape that
+// produced the running-cost bug: an in-flight attempt has start/vmStartTime
+// and a cost rate but no end timestamps yet. The mapper must carry all of it
+// through so the domain can accrue cost for the open window.
+func TestParseDetailedMetadata_RunningAttempt(t *testing.T) {
+	jsonData := `{
+		"id": "wf-run",
+		"workflowName": "TestWF",
+		"status": "Running",
+		"calls": {
+			"TestWF.Align": [{
+				"executionStatus": "Running",
+				"shardIndex": 0,
+				"attempt": 1,
+				"start": "2026-07-16T12:52:24.020Z",
+				"vmStartTime": "2026-07-16T12:52:45.457Z",
+				"vmCostPerHour": 0.204282,
+				"runtimeAttributes": {"cpu": "12", "memory": "54 GB", "preemptible": "2"}
+			}]
+		}
+	}`
+
+	wf, err := ParseDetailedMetadata([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("ParseDetailedMetadata() error = %v", err)
+	}
+
+	calls := wf.Calls["TestWF.Align"]
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	c := calls[0]
+
+	if c.Status != workflow.StatusRunning {
+		t.Errorf("Status = %v, want Running", c.Status)
+	}
+	if c.Start.IsZero() {
+		t.Errorf("Start should be parsed")
+	}
+	if !c.End.IsZero() {
+		t.Errorf("End must stay zero for a running attempt, got %v", c.End)
+	}
+	if c.VMStartTime.IsZero() {
+		t.Errorf("VMStartTime should be parsed")
+	}
+	if !c.VMEndTime.IsZero() {
+		t.Errorf("VMEndTime must stay zero for a running attempt, got %v", c.VMEndTime)
+	}
+	if c.VMCostPerHour != 0.204282 {
+		t.Errorf("VMCostPerHour = %v, want 0.204282", c.VMCostPerHour)
+	}
+	if c.CPU != "12" || c.Memory != "54 GB" || c.Preemptible != "2" {
+		t.Errorf("runtime attributes not extracted: cpu=%q mem=%q preempt=%q", c.CPU, c.Memory, c.Preemptible)
+	}
+}
+
+// TestParseDetailedMetadata_QueuedAttemptWithoutTimestamps ensures attempts
+// that have not started (queued in Cromwell) map cleanly with zero times.
+func TestParseDetailedMetadata_QueuedAttemptWithoutTimestamps(t *testing.T) {
+	jsonData := `{
+		"id": "wf-q",
+		"workflowName": "TestWF",
+		"status": "Running",
+		"calls": {
+			"TestWF.Waiting": [{
+				"executionStatus": "QueuedInCromwell",
+				"shardIndex": -1,
+				"attempt": 1
+			}]
+		}
+	}`
+
+	wf, err := ParseDetailedMetadata([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("ParseDetailedMetadata() error = %v", err)
+	}
+
+	c := wf.Calls["TestWF.Waiting"][0]
+	if !c.Start.IsZero() || !c.End.IsZero() || !c.VMStartTime.IsZero() || !c.VMEndTime.IsZero() {
+		t.Errorf("all timestamps should be zero for a queued attempt: %+v", c)
+	}
+	if c.VMCostPerHour != 0 {
+		t.Errorf("VMCostPerHour should be zero, got %v", c.VMCostPerHour)
+	}
+}
+
+// TestParseDetailedMetadata_NestedSubworkflows exercises two levels of
+// expanded subworkflow metadata, the shape the cost breakdown recurses over.
+func TestParseDetailedMetadata_NestedSubworkflows(t *testing.T) {
+	jsonData := `{
+		"id": "wf-root",
+		"workflowName": "Root",
+		"status": "Running",
+		"calls": {
+			"Root.Outer": [{
+				"executionStatus": "Running",
+				"shardIndex": 0,
+				"attempt": 1,
+				"subWorkflowId": "sub-1",
+				"subWorkflowMetadata": {
+					"id": "sub-1",
+					"workflowName": "Outer",
+					"status": "Running",
+					"calls": {
+						"Outer.Inner": [{
+							"executionStatus": "Running",
+							"shardIndex": -1,
+							"attempt": 1,
+							"subWorkflowId": "sub-2",
+							"subWorkflowMetadata": {
+								"id": "sub-2",
+								"workflowName": "Inner",
+								"status": "Running",
+								"calls": {
+									"Inner.Leaf": [{
+										"executionStatus": "Done",
+										"shardIndex": -1,
+										"attempt": 1,
+										"start": "2026-07-16T10:00:00.000Z",
+										"end": "2026-07-16T11:00:00.000Z",
+										"vmStartTime": "2026-07-16T10:05:00.000Z",
+										"vmEndTime": "2026-07-16T10:55:00.000Z",
+										"vmCostPerHour": 0.5
+									}]
+								}
+							}
+						}]
+					}
+				}
+			}]
+		}
+	}`
+
+	wf, err := ParseDetailedMetadata([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("ParseDetailedMetadata() error = %v", err)
+	}
+
+	outer := wf.Calls["Root.Outer"][0]
+	if outer.SubWorkflowID != "sub-1" {
+		t.Errorf("SubWorkflowID = %q, want sub-1", outer.SubWorkflowID)
+	}
+	if outer.SubWorkflowMetadata == nil {
+		t.Fatal("first-level subworkflow metadata not mapped")
+	}
+
+	inner := outer.SubWorkflowMetadata.Calls["Outer.Inner"][0]
+	if inner.SubWorkflowMetadata == nil {
+		t.Fatal("second-level subworkflow metadata not mapped")
+	}
+
+	leaf := inner.SubWorkflowMetadata.Calls["Inner.Leaf"][0]
+	if leaf.VMCostPerHour != 0.5 {
+		t.Errorf("leaf VMCostPerHour = %v, want 0.5", leaf.VMCostPerHour)
+	}
+	if leaf.VMStartTime.IsZero() || leaf.VMEndTime.IsZero() {
+		t.Errorf("leaf VM window should be fully parsed")
+	}
+	if got := leaf.VMEndTime.Sub(leaf.VMStartTime); got.Minutes() != 50 {
+		t.Errorf("leaf VM window = %v, want 50m", got)
+	}
+}
+
+// TestParseDetailedMetadata_NumericRuntimeAttributes covers backends that
+// report cpu/preemptible as JSON numbers instead of strings.
+func TestParseDetailedMetadata_NumericRuntimeAttributes(t *testing.T) {
+	jsonData := `{
+		"id": "wf-num",
+		"workflowName": "TestWF",
+		"status": "Succeeded",
+		"calls": {
+			"TestWF.Task": [{
+				"executionStatus": "Done",
+				"shardIndex": -1,
+				"attempt": 1,
+				"runtimeAttributes": {"cpu": 4, "preemptible": 3}
+			}]
+		}
+	}`
+
+	wf, err := ParseDetailedMetadata([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("ParseDetailedMetadata() error = %v", err)
+	}
+
+	c := wf.Calls["TestWF.Task"][0]
+	if c.CPU != "4" {
+		t.Errorf("numeric cpu not normalized, got %q", c.CPU)
+	}
+	if c.Preemptible != "3" {
+		t.Errorf("numeric preemptible not normalized, got %q", c.Preemptible)
+	}
+}

--- a/internal/infrastructure/telemetry/service.go
+++ b/internal/infrastructure/telemetry/service.go
@@ -1,45 +1,16 @@
 package telemetry
 
-import "time"
+import "github.com/lmtani/pumbaa/internal/application/ports"
 
-// Event represents a tracked user action
-type Event struct {
-	Command   string
-	Duration  int64 // milliseconds
-	Success   bool
-	Error     string
-	Version   string
-	OS        string
-	Arch      string
-	Timestamp int64
-}
+// The telemetry contract lives in ports so interface layers depend on it
+// without importing infrastructure; the aliases below keep this package's
+// API unchanged for the implementations and the composition root.
 
-// CommandContext holds context for command execution tracking
-type CommandContext struct {
-	AppName   string
-	Args      []string
-	StartTime time.Time
-}
+// Event represents a tracked user action.
+type Event = ports.TelemetryEvent
 
-// Service defines the interface for telemetry collection
-type Service interface {
-	// Track captures an event. It should be non-blocking.
-	Track(event Event)
+// CommandContext holds context for command execution tracking.
+type CommandContext = ports.TelemetryCommandContext
 
-	// TrackCommand tracks a command execution with automatic event creation.
-	// It handles duration calculation, command name extraction, and error details.
-	TrackCommand(ctx CommandContext, err error)
-
-	// CaptureError captures an error with operation context.
-	// Use this for errors that occur outside the normal command flow,
-	// such as errors in TUI interactions or background operations.
-	CaptureError(operation string, err error)
-
-	// AddBreadcrumb logs an event that will appear as context when an error occurs.
-	// Breadcrumbs create a trail of events leading up to an error.
-	// Categories: "app", "navigation", "user", "http", "query"
-	AddBreadcrumb(category, message string)
-
-	// Close flushes any pending events.
-	Close()
-}
+// Service defines the interface for telemetry collection.
+type Service = ports.Telemetry

--- a/internal/interfaces/cli/handler/chat.go
+++ b/internal/interfaces/cli/handler/chat.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/lmtani/pumbaa/internal/application/ports"
 	"github.com/lmtani/pumbaa/internal/config"
-	"github.com/lmtani/pumbaa/internal/infrastructure/telemetry"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/chat"
 )
@@ -136,12 +135,12 @@ Use **only** to understand or explain WDL definitions.
 
 type ChatHandler struct {
 	config       *config.Config
-	telemetry    telemetry.Service
+	telemetry    ports.Telemetry
 	chatDeps     ChatDepsProvider
 	sessionStore SessionStoreProvider
 }
 
-func NewChatHandler(cfg *config.Config, ts telemetry.Service, chatDeps ChatDepsProvider, sessionStore SessionStoreProvider) *ChatHandler {
+func NewChatHandler(cfg *config.Config, ts ports.Telemetry, chatDeps ChatDepsProvider, sessionStore SessionStoreProvider) *ChatHandler {
 	return &ChatHandler{config: cfg, telemetry: ts, chatDeps: chatDeps, sessionStore: sessionStore}
 }
 

--- a/internal/interfaces/cli/handler/chat.go
+++ b/internal/interfaces/cli/handler/chat.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lmtani/pumbaa/internal/config"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/chat"
+	"github.com/lmtani/pumbaa/internal/prompts"
 )
 
 // ChatDepsProvider builds the chat dependency bundle (LLM, agent tools,
@@ -31,107 +32,6 @@ type SessionStoreProvider func() (ports.ChatSessionStore, error)
 // Session scope shared with the embedded TUI chat (see ports package).
 const appName = ports.DefaultChatAppName
 const defaultUserID = ports.DefaultChatUserID
-
-const systemInstruction = `You are Pumbaa, a helpful assistant specialized in bioinformatics workflows and Cromwell/WDL.
-
-You have access to the "pumbaa" tool with these actions:
-
-# Cromwell + WDL Agent
-
-This agent operates in **two distinct domains**.  
-**Never mix runtime operations with WDL definitions.**
-
----
-
-## 1. Execution Operations (Cromwell Runtime)
-
-Use **only** when the question is about workflows already submitted:
-status, failures, logs, outputs, or runtime metadata.
-
-### Actions
-- action="query"  
-  Search workflow executions  
-  Optional: status (Running | Succeeded | Failed), name
-
-- action="status"  
-  Get execution status  
-  Required: workflow_id
-
-- action="metadata"  
-  Get full execution metadata (calls, inputs, outputs)  
-  Required: workflow_id
-
-- action="outputs"  
-  List output files  
-  Required: workflow_id
-
-- action="logs"  
-  Get log file paths for debugging  
-  Required: workflow_id
-
----
-
-## 2. Files (Google Cloud Storage)
-
-Use **only** to read real files produced by executions.
-
-- action="gcs_download"
-  Read file from GCS
-  Required: path (gs://bucket/file)
-
----
-
-## 2b. Local files (user's working directory)
-
-Use to save scripts or files the user asks for — e.g. a bash script that
-fetches a task's inputs with gsutil and reruns the analysis locally with
-docker for debugging.
-
-- action="write_file"
-  Write a text file relative to the current working directory
-  Required: path (relative), content
-  Optional: executable=true for scripts, overwrite=true to replace
-
----
-
-## 3. Knowledge Base (Workflow WDL Context)
-
-Use **only** to understand or explain WDL definitions.  
-**Does not access runtime or real executions.**
-
-### Actions
-- action="wdl_list"  
-  List indexed WDL tasks and workflows
-
-- action="wdl_search"  
-  Search by name or command content  
-  Required: query
-
-- action="wdl_info"  
-  Get task or workflow details  
-  Required: name, type (task | workflow)
-
----
-
-## Decision Rules
-
-- “Status / failed / logs / outputs?” → **Cromwell**
-- “What does this task do / inputs / command?” → **WDL**
-- Failure debugging:
-  1. Cromwell (query → logs)
-  2. GCS (gcs_download)
-  3. WDL **only to explain the code**
-
----
-
-## Guidelines
-
-- Prefer query before using workflow_id
-- Do not mix runtime (Cromwell) with definition (WDL)
-- Be concise and technical
-- Use markdown to format responses
-- Respond in the user's language (EN or PT)
-`
 
 type ChatHandler struct {
 	config       *config.Config
@@ -310,7 +210,7 @@ func (h *ChatHandler) Run(sessionID string, rebuildIndex bool) error {
 	h.telemetry.AddBreadcrumb("chat", fmt.Sprintf("using LLM provider: %s", h.config.LLMProvider))
 	fmt.Printf("Using LLM: %s | Cromwell: %s\n", deps.LLM.Name(), h.config.CromwellHost)
 
-	m := chat.NewModel(deps.LLM, deps.Tools, systemInstruction, svc, sess)
+	m := chat.NewModel(deps.LLM, deps.Tools, prompts.Chat, svc, sess)
 	m.SetStandalone(true) // Running directly from CLI, not embedded in TUI
 
 	p := tea.NewProgram(&m, tea.WithAltScreen())

--- a/internal/interfaces/cli/handler/dashboard.go
+++ b/internal/interfaces/cli/handler/dashboard.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/lmtani/pumbaa/internal/application/ports"
 	workflowapp "github.com/lmtani/pumbaa/internal/application/workflow"
-	"github.com/lmtani/pumbaa/internal/infrastructure/telemetry"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui"
 )
 
 // DashboardHandler handles the dashboard TUI command.
 type DashboardHandler struct {
 	repository    ports.WorkflowRepository
-	telemetry     telemetry.Service
+	telemetry     ports.Telemetry
 	monitoringUC  *workflowapp.MonitoringUseCase
 	fileProvider  ports.FileProvider
 	batchLogsUC   *workflowapp.GetBatchLogsUseCase
@@ -29,7 +28,7 @@ type DashboardHandler struct {
 // NewDashboardHandler creates a new dashboard handler.
 func NewDashboardHandler(
 	client ports.WorkflowRepository,
-	ts telemetry.Service,
+	ts ports.Telemetry,
 	muc *workflowapp.MonitoringUseCase,
 	fp ports.FileProvider,
 	bluc *workflowapp.GetBatchLogsUseCase,

--- a/internal/interfaces/cli/handler/debug.go
+++ b/internal/interfaces/cli/handler/debug.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/lmtani/pumbaa/internal/application/ports"
 	workflowapp "github.com/lmtani/pumbaa/internal/application/workflow"
-	"github.com/lmtani/pumbaa/internal/infrastructure/telemetry"
 	"github.com/lmtani/pumbaa/internal/interfaces/tui"
 )
 
 // DebugHandler handles workflow debug TUI commands.
 type DebugHandler struct {
 	repository   ports.WorkflowRepository
-	telemetry    telemetry.Service
+	telemetry    ports.Telemetry
 	monitoringUC *workflowapp.MonitoringUseCase
 	fileProvider ports.FileProvider
 	batchLogsUC  *workflowapp.GetBatchLogsUseCase
@@ -26,7 +25,7 @@ type DebugHandler struct {
 // NewDebugHandler creates a new debug handler.
 func NewDebugHandler(
 	client ports.WorkflowRepository,
-	ts telemetry.Service,
+	ts ports.Telemetry,
 	muc *workflowapp.MonitoringUseCase,
 	fp ports.FileProvider,
 	bluc *workflowapp.GetBatchLogsUseCase,

--- a/internal/interfaces/tui/debug/chat_context.go
+++ b/internal/interfaces/tui/debug/chat_context.go
@@ -287,23 +287,3 @@ func formatChatDuration(d time.Duration) string {
 	mins := int(d.Minutes()) % 60
 	return fmt.Sprintf("%dh %dm", hours, mins)
 }
-
-// taskDebugSystemInstruction is the system instruction for task debugging chat.
-const taskDebugSystemInstruction = `You are Pumbaa, a helpful assistant specialized in debugging Cromwell/WDL workflow tasks.
-
-The user has provided context about a specific task execution that may have failed or has issues. Your job is to:
-
-1. **Analyze the failure**: Look at the stderr, return code, and failure messages to identify the root cause
-2. **Check resource usage**: If monitoring data is provided, identify potential resource issues (OOM, disk full, etc.)
-3. **Provide actionable recommendations**: Suggest specific fixes or next steps
-4. **Be concise**: Focus on the most likely cause and solution
-
-Guidelines:
-- Be technical and direct
-- Use markdown formatting for clarity
-- If you see common error patterns (OOM killer, disk space, permission denied), identify them immediately
-- Suggest concrete changes to WDL runtime attributes if resource issues are detected
-- Respond in the user's language (English or Portuguese)
-
-You have access to tools for querying Cromwell and reading files if the user needs additional information.
-`

--- a/internal/interfaces/tui/debug/modal_chat.go
+++ b/internal/interfaces/tui/debug/modal_chat.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/lmtani/pumbaa/internal/interfaces/tui/common"
+	"github.com/lmtani/pumbaa/internal/prompts"
 )
 
 // handleChatContextLoaded handles the completion of context collection.
@@ -15,7 +16,7 @@ func (m Model) handleChatContextLoaded(msg chatContextLoadedMsg) (tea.Model, tea
 	m.loadingMessage = ""
 
 	navMsg := common.NavigateToChatMsg{
-		SystemInstruction: fmt.Sprintf("%s\n\n---\n\n%s", taskDebugSystemInstruction, msg.context),
+		SystemInstruction: fmt.Sprintf("%s\n\n---\n\n%s", prompts.TaskDebug, msg.context),
 		ContextSummary:    m.buildChatContextSummary(msg.errors),
 		ContextLabel:      m.buildChatContextLabel(),
 	}

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -1,0 +1,132 @@
+// Package prompts holds the system instructions for pumbaa's LLM agents in
+// one place, so the personas can be reviewed and iterated on together. It is
+// dependency-free and importable from any layer.
+//
+// The resource-recommendation prompts stay in
+// infrastructure/recommendation: they are templates tightly coupled to that
+// generator's data formatting, not standalone personas.
+package prompts
+
+// Chat is the system instruction for the general chat agent (pumbaa chat
+// and the TUI chat screen).
+const Chat = `You are Pumbaa, a helpful assistant specialized in bioinformatics workflows and Cromwell/WDL.
+
+You have access to the "pumbaa" tool with these actions:
+
+# Cromwell + WDL Agent
+
+This agent operates in **two distinct domains**.  
+**Never mix runtime operations with WDL definitions.**
+
+---
+
+## 1. Execution Operations (Cromwell Runtime)
+
+Use **only** when the question is about workflows already submitted:
+status, failures, logs, outputs, or runtime metadata.
+
+### Actions
+- action="query"  
+  Search workflow executions  
+  Optional: status (Running | Succeeded | Failed), name
+
+- action="status"  
+  Get execution status  
+  Required: workflow_id
+
+- action="metadata"  
+  Get full execution metadata (calls, inputs, outputs)  
+  Required: workflow_id
+
+- action="outputs"  
+  List output files  
+  Required: workflow_id
+
+- action="logs"  
+  Get log file paths for debugging  
+  Required: workflow_id
+
+---
+
+## 2. Files (Google Cloud Storage)
+
+Use **only** to read real files produced by executions.
+
+- action="gcs_download"
+  Read file from GCS
+  Required: path (gs://bucket/file)
+
+---
+
+## 2b. Local files (user's working directory)
+
+Use to save scripts or files the user asks for — e.g. a bash script that
+fetches a task's inputs with gsutil and reruns the analysis locally with
+docker for debugging.
+
+- action="write_file"
+  Write a text file relative to the current working directory
+  Required: path (relative), content
+  Optional: executable=true for scripts, overwrite=true to replace
+
+---
+
+## 3. Knowledge Base (Workflow WDL Context)
+
+Use **only** to understand or explain WDL definitions.  
+**Does not access runtime or real executions.**
+
+### Actions
+- action="wdl_list"  
+  List indexed WDL tasks and workflows
+
+- action="wdl_search"  
+  Search by name or command content  
+  Required: query
+
+- action="wdl_info"  
+  Get task or workflow details  
+  Required: name, type (task | workflow)
+
+---
+
+## Decision Rules
+
+- “Status / failed / logs / outputs?” → **Cromwell**
+- “What does this task do / inputs / command?” → **WDL**
+- Failure debugging:
+  1. Cromwell (query → logs)
+  2. GCS (gcs_download)
+  3. WDL **only to explain the code**
+
+---
+
+## Guidelines
+
+- Prefer query before using workflow_id
+- Do not mix runtime (Cromwell) with definition (WDL)
+- Be concise and technical
+- Use markdown to format responses
+- Respond in the user's language (EN or PT)
+`
+
+// TaskDebug is the system instruction for the task-debugging chat opened
+// from the debug screen; the task's execution context is appended to it.
+const TaskDebug = `You are Pumbaa, a helpful assistant specialized in debugging Cromwell/WDL workflow tasks.
+
+The user has provided context about a specific task execution that may have failed or has issues. Your job is to:
+
+1. **Analyze the failure**: Look at the stderr, return code, and failure messages to identify the root cause
+2. **Check resource usage**: If monitoring data is provided, identify potential resource issues (OOM, disk full, etc.)
+3. **Provide actionable recommendations**: Suggest specific fixes or next steps
+4. **Be concise**: Focus on the most likely cause and solution
+
+Guidelines:
+- Be technical and direct
+- Use markdown formatting for clarity
+- If you see common error patterns (OOM killer, disk space, permission denied), identify them immediately
+- Suggest concrete changes to WDL runtime attributes if resource issues are detected
+- Respond in the user's language (English or Portuguese)
+
+You have access to tools for querying Cromwell and reading files if the user needs additional information.
+`


### PR DESCRIPTION
## Context and problem

Item 5 of the improvement backlog grouped three small leftovers from the recent architecture review:

- The telemetry contract (its interface and event types) was defined in infrastructure, making it the last dependency from the interface layer into infrastructure — every other such contract already lives in the application ports.
- The LLM agents' system instructions were scattered: the chat persona sat inline in the CLI chat handler (~100 lines of prompt inside command wiring) and the task-debugging persona inside the debug screen, so reviewing or iterating on the personas meant hunting through unrelated files.
- The Cromwell metadata mapper — pure parsing logic, and the layer where the recent running-cost bug was born — only had happy-path tests.

## What was done

- **Telemetry contract moved to ports.** Same pattern already applied to the session store and the update checker: the interface and its two event types now live in the application ports, type aliases keep the telemetry package's API identical for its implementations and the composition root, and the handlers now depend on the port. The interface layer now has zero infrastructure imports.
- **Agent personas consolidated.** A new dependency-free prompts package holds the chat persona and the task-debugging persona, each documented with where it is used. The resource-recommendation prompts intentionally stay with their generator — they are data-formatting templates coupled to that component, not standalone personas.
- **Mapper edge-case tests.** Four new cases pin the metadata shapes that matter in production: a running attempt carrying start time, VM start time and cost rate but no end timestamps (the exact shape behind the running-cost bug); a queued attempt with no timestamps at all; two levels of expanded subworkflow metadata; and backends reporting CPU/preemptible as JSON numbers instead of strings.

## Decisions and rationale

- **Aliases over a breaking move.** Relocating the telemetry types wholesale would touch every implementation for zero behavioral gain; aliases give the layering fix with a minimal diff.
- **Prompts in their own package rather than near the agents' infrastructure.** The TUI also needs the debugging persona; putting prompts under infrastructure would recreate the exact layering violation just removed. A leaf package with no dependencies is importable from anywhere without cycles or boundary crossings.

## Impacts and risks

- No behavior changes anywhere; the prompts moved verbatim and the telemetry types are identical under aliases.
- Merge note: the lint-enforcement branch touches neighboring lines in the chat handler and the debug screen's context builder; whichever merges second needs a trivial rebase.

## How to validate

- Full test suite passes; the four new mapper tests run with the rest.
- The import graph confirms the interface layer no longer imports any infrastructure package.
