### PR TITLE
feat(agents): failures, read_log, cost and preemption actions for the chat agent

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -208,6 +208,10 @@ func (c *Container) ChatDependencies(rebuildWDLIndex bool, extraTools ...tool.To
 	if err != nil {
 		return nil, fmt.Errorf("session service initialization failed: %w", err)
 	}
-	agentTools := tools.GetAllTools(c.CromwellClient, c.initWDLRepository(rebuildWDLIndex), extraTools...)
+	agentTools := tools.GetAllTools(tools.Deps{
+		Repo:    c.CromwellClient,
+		Fetcher: c.CromwellClient,
+		WDLRepo: c.initWDLRepository(rebuildWDLIndex),
+	}, extraTools...)
 	return &tui.ChatDependencies{LLM: llmModel, Tools: agentTools, SessionSvc: svc}, nil
 }

--- a/internal/domain/workflow/failures.go
+++ b/internal/domain/workflow/failures.go
@@ -1,0 +1,194 @@
+// failures.go aggregates workflow failures into deduplicated groups: the
+// same root cause across hundreds of shards collapses into one entry. Used
+// by the debug TUI's failure summary and by the chat agent's failures action.
+package workflow
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// FailureTask identifies one failed task instance within a failure group.
+type FailureTask struct {
+	Name       string // Short task name (tree label or task name)
+	ShardIndex int    // -1 for non-scattered tasks
+	Stderr     string // Path to the attempt's stderr, when known
+}
+
+// FailureGroup aggregates failed tasks sharing the same error signature.
+type FailureGroup struct {
+	Signature string        // Normalized message used for grouping
+	Sample    string        // One raw message, representative of the group
+	Tasks     []FailureTask // Affected task instances, in traversal order
+}
+
+// FailureSummary is a Value Object with the workflow's failures grouped by
+// root-cause signature, largest group first.
+type FailureSummary struct {
+	Groups      []FailureGroup
+	FailedTasks int // Distinct failed task instances across all groups
+}
+
+// Patterns of run-specific noise stripped from messages before grouping, so
+// the same error across hundreds of shards collapses into one group.
+var (
+	sigUUIDRe    = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	sigGCSRe     = regexp.MustCompile(`gs://\S+`)
+	sigPathRe    = regexp.MustCompile(`(/[\w.\-]+){3,}`)
+	sigShardRe   = regexp.MustCompile(`(?i)\b(shard|index|attempt)[ :=]+\d+`)
+	sigLongNumRe = regexp.MustCompile(`\b\d{4,}\b`)
+	sigSpaceRe   = regexp.MustCompile(`\s+`)
+)
+
+// NormalizeFailureSignature strips run-specific details (paths, IDs, shard
+// numbers) from a failure message so equivalent errors group together.
+func NormalizeFailureSignature(msg string) string {
+	s := sigUUIDRe.ReplaceAllString(msg, "<id>")
+	s = sigGCSRe.ReplaceAllString(s, "<path>")
+	s = sigPathRe.ReplaceAllString(s, "<path>")
+	s = sigShardRe.ReplaceAllString(s, "$1 <n>")
+	s = sigLongNumRe.ReplaceAllString(s, "<n>")
+	s = sigSpaceRe.ReplaceAllString(strings.TrimSpace(s), " ")
+	return s
+}
+
+// RootCauseMessages returns the deepest CausedBy messages of a failure —
+// the actual root causes rather than the "Workflow failed" wrappers.
+func RootCauseMessages(f Failure) []string {
+	if len(f.CausedBy) == 0 {
+		if strings.TrimSpace(f.Message) == "" {
+			return nil
+		}
+		return []string{f.Message}
+	}
+	var msgs []string
+	for _, cause := range f.CausedBy {
+		msgs = append(msgs, RootCauseMessages(cause)...)
+	}
+	if len(msgs) == 0 && strings.TrimSpace(f.Message) != "" {
+		msgs = []string{f.Message}
+	}
+	return msgs
+}
+
+// FailureGrouper accumulates failure messages into deduplicated groups.
+// Callers feed it failed task instances (from the workflow itself or from a
+// UI tree) and read the result with Sorted.
+type FailureGrouper struct {
+	index  map[string]int
+	groups []FailureGroup
+}
+
+// NewFailureGrouper creates an empty grouper.
+func NewFailureGrouper() *FailureGrouper {
+	return &FailureGrouper{index: make(map[string]int)}
+}
+
+// Add records one failure message for a task instance.
+func (g *FailureGrouper) Add(task FailureTask, msg string) {
+	sig := NormalizeFailureSignature(msg)
+	idx, ok := g.index[sig]
+	if !ok {
+		g.groups = append(g.groups, FailureGroup{Signature: sig, Sample: msg})
+		idx = len(g.groups) - 1
+		g.index[sig] = idx
+	}
+	g.groups[idx].Tasks = append(g.groups[idx].Tasks, task)
+}
+
+// AddFailures adds the root causes of a failure list, counting each
+// signature at most once per task.
+func (g *FailureGrouper) AddFailures(task FailureTask, failures []Failure) {
+	seen := make(map[string]bool)
+	for _, f := range failures {
+		for _, msg := range RootCauseMessages(f) {
+			sig := NormalizeFailureSignature(msg)
+			if seen[sig] {
+				continue
+			}
+			seen[sig] = true
+			g.Add(task, msg)
+		}
+	}
+}
+
+// Sorted returns the groups ordered by task count, largest first.
+func (g *FailureGrouper) Sorted() []FailureGroup {
+	groups := g.groups
+	sort.SliceStable(groups, func(i, j int) bool {
+		return len(groups[i].Tasks) > len(groups[j].Tasks)
+	})
+	return groups
+}
+
+// CalculateFailureSummary groups every failed task instance in the workflow
+// by root-cause signature, recursing into loaded subworkflow metadata. Only
+// the final attempt of each task/shard counts: preempted-then-retried
+// attempts are not failures of the task. When no failed task carries a
+// message, the workflow-level failures are used as fallback.
+func (w *Workflow) CalculateFailureSummary() *FailureSummary {
+	grouper := NewFailureGrouper()
+	failed := 0
+
+	var walk func(calls map[string][]Call, scope string)
+	walk = func(calls map[string][]Call, scope string) {
+		for callName, callList := range calls {
+			short := preemptionShortTaskName(callName)
+
+			shardGroups := make(map[int][]Call)
+			for _, call := range callList {
+				if call.SubWorkflowMetadata != nil {
+					walk(call.SubWorkflowMetadata.Calls, subworkflowScope(scope, callName, call.ShardIndex))
+					continue
+				}
+				if call.SubWorkflowID != "" {
+					// Subworkflow not loaded: its tasks are absent here.
+					continue
+				}
+				shardGroups[call.ShardIndex] = append(shardGroups[call.ShardIndex], call)
+			}
+
+			for shardIndex, attempts := range shardGroups {
+				sort.Slice(attempts, func(i, j int) bool {
+					return attempts[i].Attempt < attempts[j].Attempt
+				})
+				last := attempts[len(attempts)-1]
+				if last.Status != StatusFailed {
+					continue
+				}
+				failed++
+				task := FailureTask{
+					Name:       failureTaskLabel(short, shardIndex),
+					ShardIndex: shardIndex,
+					Stderr:     last.Stderr,
+				}
+				if len(last.Failures) > 0 {
+					grouper.AddFailures(task, last.Failures)
+				} else {
+					grouper.Add(task, "(no failure message in metadata)")
+				}
+			}
+		}
+	}
+	walk(w.Calls, "")
+
+	if len(grouper.groups) == 0 && len(w.Failures) > 0 {
+		grouper.AddFailures(FailureTask{Name: "(workflow)", ShardIndex: -1}, w.Failures)
+	}
+
+	return &FailureSummary{
+		Groups:      grouper.Sorted(),
+		FailedTasks: failed,
+	}
+}
+
+// failureTaskLabel names a failed task instance, with the shard suffix for
+// scattered tasks.
+func failureTaskLabel(short string, shardIndex int) string {
+	if shardIndex >= 0 {
+		return short + "[" + strconv.Itoa(shardIndex) + "]"
+	}
+	return short
+}

--- a/internal/domain/workflow/failures_test.go
+++ b/internal/domain/workflow/failures_test.go
@@ -1,0 +1,136 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFailureSignature(t *testing.T) {
+	a := NormalizeFailureSignature(
+		"Task failed (shard 3): exit code 137. See gs://bucket/wf/11111111-2222-3333-4444-555555555555/call-X/shard-3/stderr")
+	b := NormalizeFailureSignature(
+		"Task failed (shard 47): exit code 137. See gs://bucket/wf/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/call-X/shard-47/stderr")
+
+	if a != b {
+		t.Errorf("signatures should match:\n a=%q\n b=%q", a, b)
+	}
+
+	c := NormalizeFailureSignature("Task failed (shard 3): exit code 1.")
+	if a == c {
+		t.Error("different exit codes should produce different signatures")
+	}
+}
+
+func TestRootCauseMessages(t *testing.T) {
+	f := Failure{
+		Message: "Workflow failed",
+		CausedBy: []Failure{
+			{Message: "Job failed", CausedBy: []Failure{{Message: "OOM killed"}}},
+			{Message: "Disk full"},
+		},
+	}
+
+	msgs := RootCauseMessages(f)
+	if len(msgs) != 2 || msgs[0] != "OOM killed" || msgs[1] != "Disk full" {
+		t.Errorf("RootCauseMessages = %v, want [OOM killed, Disk full]", msgs)
+	}
+}
+
+func TestCalculateFailureSummaryGroupsAcrossSubworkflows(t *testing.T) {
+	s, e := hoursApart("2026-07-06T06:00:00Z", 1)
+
+	// Two subworkflow instances, each with the same failing task; a third
+	// task fails with a different error.
+	makeSub := func(stderr string) *Workflow {
+		return &Workflow{
+			Calls: map[string][]Call{
+				"Sub.Align": {{
+					Name: "Sub.Align", ShardIndex: -1, Attempt: 1, Status: StatusFailed,
+					Start: s, End: e, Stderr: stderr,
+					Failures: []Failure{{Message: "Job exit code 137 at gs://bucket/run/stderr"}},
+				}},
+			},
+		}
+	}
+
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.SubA": {{Name: "WF.SubA", ShardIndex: 0, SubWorkflowID: "a", SubWorkflowMetadata: makeSub("gs://b/a/stderr")}},
+			"WF.SubB": {{Name: "WF.SubB", ShardIndex: 1, SubWorkflowID: "b", SubWorkflowMetadata: makeSub("gs://b/b/stderr")}},
+			"WF.Other": {{
+				Name: "WF.Other", ShardIndex: -1, Attempt: 1, Status: StatusFailed,
+				Failures: []Failure{{Message: "PAPI error code 9: disk full"}},
+			}},
+		},
+	}
+
+	sum := wf.CalculateFailureSummary()
+
+	if sum.FailedTasks != 3 {
+		t.Errorf("FailedTasks = %d, want 3", sum.FailedTasks)
+	}
+	if len(sum.Groups) != 2 {
+		t.Fatalf("got %d groups, want 2: %+v", len(sum.Groups), sum.Groups)
+	}
+	// Largest group first: the two Align failures share a signature.
+	if len(sum.Groups[0].Tasks) != 2 || !strings.Contains(sum.Groups[0].Sample, "exit code 137") {
+		t.Errorf("first group should be the 2 Align failures, got %+v", sum.Groups[0])
+	}
+	if sum.Groups[0].Tasks[0].Stderr == "" {
+		t.Errorf("failed task should carry its stderr path")
+	}
+}
+
+func TestCalculateFailureSummaryUsesFinalAttemptOnly(t *testing.T) {
+	s, e := hoursApart("2026-07-06T06:00:00Z", 1)
+
+	// Attempt 1 preempted (RetryableFailure), attempt 2 succeeded: the task
+	// did NOT fail.
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.Retried": {
+				{Name: "WF.Retried", ShardIndex: -1, Attempt: 1, Status: "RetryableFailure", Start: s, End: e,
+					Failures: []Failure{{Message: "preempted"}}},
+				{Name: "WF.Retried", ShardIndex: -1, Attempt: 2, Status: StatusSucceeded, Start: s, End: e},
+			},
+		},
+	}
+
+	sum := wf.CalculateFailureSummary()
+
+	if sum.FailedTasks != 0 || len(sum.Groups) != 0 {
+		t.Errorf("retried-then-succeeded task must not appear as failed: %+v", sum)
+	}
+}
+
+func TestCalculateFailureSummaryFallsBackToWorkflowFailures(t *testing.T) {
+	wf := &Workflow{
+		Failures: []Failure{{Message: "Required workflow input 'wf.sample' not specified"}},
+	}
+
+	sum := wf.CalculateFailureSummary()
+
+	if len(sum.Groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(sum.Groups))
+	}
+	if sum.Groups[0].Tasks[0].Name != "(workflow)" {
+		t.Errorf("fallback task = %q, want (workflow)", sum.Groups[0].Tasks[0].Name)
+	}
+}
+
+func TestCalculateFailureSummaryShardLabels(t *testing.T) {
+	wf := &Workflow{
+		Calls: map[string][]Call{
+			"WF.Scatter": {
+				{Name: "WF.Scatter", ShardIndex: 3, Attempt: 1, Status: StatusFailed,
+					Failures: []Failure{{Message: "boom"}}},
+			},
+		},
+	}
+
+	sum := wf.CalculateFailureSummary()
+
+	if got := sum.Groups[0].Tasks[0].Name; got != "Scatter[3]" {
+		t.Errorf("task label = %q, want Scatter[3]", got)
+	}
+}

--- a/internal/infrastructure/agents/tools/chatpath_test.go
+++ b/internal/infrastructure/agents/tools/chatpath_test.go
@@ -26,7 +26,7 @@ type chatToolDefinition interface {
 // tool call — functiontool.Run with a nil tool.Context and raw map args —
 // so a regression in this layer (not just the registry) fails loudly.
 func TestChatExecutePathWDL(t *testing.T) {
-	all := GetAllTools(nil, stubWDLRepo{})
+	all := GetAllTools(Deps{WDLRepo: stubWDLRepo{}})
 
 	var td chatToolDefinition
 	for _, tl := range all {

--- a/internal/infrastructure/agents/tools/cromwell/actions_test.go
+++ b/internal/infrastructure/agents/tools/cromwell/actions_test.go
@@ -1,0 +1,265 @@
+package cromwell
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// stubFetcher returns a pre-built workflow, standing in for the expanded
+// metadata fetch + parse round trip.
+type stubFetcher struct {
+	wf      *workflow.Workflow
+	apiCost float64
+	err     error
+}
+
+func (s *stubFetcher) GetRawMetadataWithOptions(ctx context.Context, workflowID string, expand bool) ([]byte, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return []byte("{}"), nil
+}
+
+func (s *stubFetcher) ParseMetadata(data []byte) (*workflow.Workflow, error) {
+	return s.wf, nil
+}
+
+func (s *stubFetcher) GetWorkflowCost(ctx context.Context, workflowID string) (float64, string, error) {
+	if s.apiCost == 0 {
+		return 0, "", errors.New("cost endpoint unavailable")
+	}
+	return s.apiCost, "USD", nil
+}
+
+func window(h float64) (time.Time, time.Time) {
+	s, _ := time.Parse(time.RFC3339, "2026-07-16T06:00:00Z")
+	return s, s.Add(time.Duration(h * float64(time.Hour)))
+}
+
+func failedWorkflow() *workflow.Workflow {
+	s, e := window(1)
+	return &workflow.Workflow{
+		Status: workflow.StatusFailed,
+		Calls: map[string][]workflow.Call{
+			"WF.Align": {
+				{Name: "WF.Align", ShardIndex: 0, Attempt: 1, Status: workflow.StatusFailed, Start: s, End: e,
+					Stderr:   "gs://bucket/align-0/stderr",
+					Failures: []workflow.Failure{{Message: "exit code 137 at gs://bucket/align-0/stderr"}}},
+				{Name: "WF.Align", ShardIndex: 1, Attempt: 1, Status: workflow.StatusFailed, Start: s, End: e,
+					Stderr:   "gs://bucket/align-1/stderr",
+					Failures: []workflow.Failure{{Message: "exit code 137 at gs://bucket/align-1/stderr"}}},
+			},
+			"WF.Sort": {
+				{Name: "WF.Sort", ShardIndex: -1, Attempt: 1, Status: workflow.StatusSucceeded, Start: s, End: e, VMCostPerHour: 0.5},
+			},
+		},
+	}
+}
+
+func TestFailuresHandlerGroupsAndHints(t *testing.T) {
+	h := NewFailuresHandler(&stubFetcher{wf: failedWorkflow()})
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "failures", WorkflowID: "wf-1"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	if data["failed_tasks"] != 2 {
+		t.Errorf("failed_tasks = %v, want 2", data["failed_tasks"])
+	}
+	groups := data["groups"].([]map[string]any)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 deduplicated group, got %+v", groups)
+	}
+	if groups[0]["count"] != 2 {
+		t.Errorf("group count = %v, want 2 (same signature across shards)", groups[0]["count"])
+	}
+	tasks := groups[0]["tasks"].([]map[string]any)
+	if tasks[0]["stderr"] == "" {
+		t.Errorf("group tasks should carry stderr paths for read_log chaining")
+	}
+}
+
+func TestFailuresHandlerRequiresWorkflowID(t *testing.T) {
+	h := NewFailuresHandler(&stubFetcher{wf: failedWorkflow()})
+	out, _ := h.Handle(context.Background(), types.Input{Action: "failures"})
+	if out.Success {
+		t.Error("missing workflow_id should fail")
+	}
+}
+
+func TestCostHandlerSeparatesUnitsAndAPITotal(t *testing.T) {
+	s, e := window(2)
+	wf := &workflow.Workflow{
+		Status: workflow.StatusSucceeded,
+		Calls: map[string][]workflow.Call{
+			"WF.Priced": {{Name: "WF.Priced", ShardIndex: -1, Attempt: 1, Status: workflow.StatusSucceeded,
+				Start: s, End: e, VMCostPerHour: 0.5, Preemptible: "2"}},
+			"WF.Unpriced": {{Name: "WF.Unpriced", ShardIndex: -1, Attempt: 1, Status: workflow.StatusSucceeded,
+				Start: s, End: e, CPU: "2", Memory: "4 GB"}},
+		},
+	}
+	h := NewCostHandler(&stubFetcher{wf: wf, apiCost: 1.05})
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "cost", WorkflowID: "wf-1"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	if data["total_cost_usd"] != 1.0 {
+		t.Errorf("total_cost_usd = %v, want 1.0 (2h × $0.5)", data["total_cost_usd"])
+	}
+	if data["estimated_total_resource_hours"] != 16.0 {
+		t.Errorf("estimated_total_resource_hours = %v, want 16 (2cpu × 4GB × 2h)", data["estimated_total_resource_hours"])
+	}
+	if data["api_total"] != 1.05 {
+		t.Errorf("api_total = %v, want 1.05", data["api_total"])
+	}
+	tasks := data["tasks"].([]map[string]any)
+	if tasks[0]["task"] != "Priced" {
+		t.Errorf("dollar-bearing task should sort first, got %+v", tasks[0])
+	}
+	if _, hasUSD := tasks[1]["cost_usd"]; hasUSD {
+		t.Errorf("estimate-only task must not report cost_usd: %+v", tasks[1])
+	}
+}
+
+func TestPreemptionHandlerReportsChains(t *testing.T) {
+	s, e := window(1)
+	s2, e2 := window(2)
+	wf := &workflow.Workflow{
+		Calls: map[string][]workflow.Call{
+			"WF.Flaky": {
+				{Name: "WF.Flaky", ShardIndex: -1, Attempt: 1, Status: "RetryableFailure", Start: s, End: e,
+					VMCostPerHour: 0.5, Preemptible: "3"},
+				{Name: "WF.Flaky", ShardIndex: -1, Attempt: 2, Status: workflow.StatusSucceeded, Start: s2, End: e2,
+					VMCostPerHour: 0.5, Preemptible: "3"},
+			},
+		},
+	}
+	h := NewPreemptionHandler(&stubFetcher{wf: wf})
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "preemption", WorkflowID: "wf-1"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	if data["total_preemptions"] != 1 {
+		t.Errorf("total_preemptions = %v, want 1", data["total_preemptions"])
+	}
+	if data["total_attempts"] != 2 {
+		t.Errorf("total_attempts = %v, want 2", data["total_attempts"])
+	}
+}
+
+// stubLogsRepo implements the subset of ports.WorkflowReader used by read_log.
+type stubLogsRepo struct {
+	logs map[string][]workflow.CallLog
+}
+
+func (s *stubLogsRepo) Query(ctx context.Context, f workflow.QueryFilter) (*workflow.QueryResult, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubLogsRepo) GetStatus(ctx context.Context, id string) (workflow.Status, error) {
+	return "", errors.New("not implemented")
+}
+func (s *stubLogsRepo) GetMetadata(ctx context.Context, id string) (*workflow.Workflow, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubLogsRepo) GetOutputs(ctx context.Context, id string) (map[string]any, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubLogsRepo) GetLogs(ctx context.Context, id string) (map[string][]workflow.CallLog, error) {
+	return s.logs, nil
+}
+
+func TestReadLogResolvesTaskAndTails(t *testing.T) {
+	dir := t.TempDir()
+	stderrPath := filepath.Join(dir, "stderr")
+	var content strings.Builder
+	for i := 1; i <= 150; i++ {
+		content.WriteString("line\n")
+	}
+	content.WriteString("FATAL: out of memory\n")
+	if err := os.WriteFile(stderrPath, []byte(content.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &stubLogsRepo{logs: map[string][]workflow.CallLog{
+		"WF.Align": {
+			{Stderr: filepath.Join(dir, "attempt1-stderr"), Stdout: "x", Attempt: 1, ShardIndex: -1},
+			{Stderr: stderrPath, Stdout: "x", Attempt: 2, ShardIndex: -1},
+		},
+	}}
+	h := NewReadLogHandler(repo)
+
+	// Short task name resolves the call; the latest attempt wins.
+	out, err := h.Handle(context.Background(), types.Input{Action: "read_log", WorkflowID: "wf-1", Task: "Align", Lines: 10})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+	data := out.Data.(map[string]any)
+	if data["path"] != stderrPath {
+		t.Errorf("path = %v, want the latest attempt's stderr", data["path"])
+	}
+	if data["total_lines"] != 151 || data["truncated"] != true {
+		t.Errorf("tail accounting wrong: %+v", data)
+	}
+	if !strings.HasSuffix(data["content"].(string), "FATAL: out of memory") {
+		t.Errorf("tail should end with the last line, got %q", data["content"])
+	}
+}
+
+func TestReadLogUnknownTaskListsAvailable(t *testing.T) {
+	repo := &stubLogsRepo{logs: map[string][]workflow.CallLog{
+		"WF.Align": {{Stderr: "s", Attempt: 1, ShardIndex: -1}},
+	}}
+	h := NewReadLogHandler(repo)
+
+	out, _ := h.Handle(context.Background(), types.Input{Action: "read_log", WorkflowID: "wf-1", Task: "Nope"})
+	if out.Success {
+		t.Fatal("unknown task should fail")
+	}
+	if !strings.Contains(out.Error, "WF.Align") {
+		t.Errorf("error should list available tasks, got %q", out.Error)
+	}
+}
+
+func TestReadLogDirectPathSkipsResolution(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "stderr")
+	if err := os.WriteFile(p, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := NewReadLogHandler(nil) // repo unused when path is explicit
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "read_log", Path: p})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+	if out.Data.(map[string]any)["content"] != "a\nb" {
+		t.Errorf("content = %q", out.Data.(map[string]any)["content"])
+	}
+}
+
+func TestTailLines(t *testing.T) {
+	tail, total := tailLines("a\nb\nc\n", 2)
+	if tail != "b\nc" || total != 3 {
+		t.Errorf("tailLines = %q/%d, want b\\nc / 3", tail, total)
+	}
+	tail, total = tailLines("", 5)
+	if tail != "" || total != 0 {
+		t.Errorf("empty content should be 0 lines, got %q/%d", tail, total)
+	}
+}

--- a/internal/infrastructure/agents/tools/cromwell/cost.go
+++ b/internal/infrastructure/agents/tools/cromwell/cost.go
@@ -1,0 +1,81 @@
+package cromwell
+
+import (
+	"context"
+	"math"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// CostHandler handles the "cost" action: the per-task cost breakdown,
+// keeping real dollars and resource-hour estimates in separate fields.
+type CostHandler struct {
+	fetcher ports.WorkflowMetadataFetcher
+}
+
+// NewCostHandler creates a new CostHandler.
+func NewCostHandler(fetcher ports.WorkflowMetadataFetcher) *CostHandler {
+	return &CostHandler{fetcher: fetcher}
+}
+
+// Handle implements types.Handler.
+func (h *CostHandler) Handle(ctx context.Context, input types.Input) (types.Output, error) {
+	const action = "cost"
+	if input.WorkflowID == "" {
+		return types.NewErrorOutput(action, "workflow_id is required"), nil
+	}
+
+	wf, err := fetchExpandedWorkflow(ctx, h.fetcher, input.WorkflowID)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	b := wf.CalculateCostBreakdown()
+
+	tasks := make([]map[string]any, 0, len(b.Tasks))
+	for _, t := range b.Tasks {
+		entry := map[string]any{
+			"task":     t.Name,
+			"percent":  round1(t.Percent),
+			"vm_hours": round1(t.VMHours),
+			"shards":   t.ShardCount,
+			"attempts": t.AttemptCount,
+		}
+		if t.ActualCost > 0 {
+			entry["cost_usd"] = round2(t.ActualCost)
+		}
+		if t.EstimatedCost > 0 {
+			entry["estimated_resource_hours"] = round2(t.EstimatedCost)
+		}
+		if !t.Preemptible {
+			entry["on_demand"] = true
+		}
+		tasks = append(tasks, entry)
+	}
+
+	data := map[string]any{
+		"id":             input.WorkflowID,
+		"status":         string(wf.Status),
+		"total_cost_usd": round2(b.ActualTotal),
+		"tasks":          tasks,
+		"note":           "running tasks accrue cost up to now; cost_usd comes from real VM rates, estimated_resource_hours is a dimensionless fallback (cpu×memGB×hours), never added to dollars",
+	}
+	if b.EstimatedTotal > 0 {
+		data["estimated_total_resource_hours"] = round2(b.EstimatedTotal)
+	}
+	if b.SubworkflowsPending > 0 {
+		data["subworkflows_not_included"] = b.SubworkflowsPending
+	}
+
+	// The API total is authoritative when the server provides it.
+	if apiCost, currency, err := h.fetcher.GetWorkflowCost(ctx, input.WorkflowID); err == nil && apiCost > 0 {
+		data["api_total"] = round2(apiCost)
+		data["api_currency"] = currency
+	}
+
+	return types.NewSuccessOutput(action, data), nil
+}
+
+func round1(v float64) float64 { return math.Round(v*10) / 10 }
+func round2(v float64) float64 { return math.Round(v*100) / 100 }

--- a/internal/infrastructure/agents/tools/cromwell/expanded.go
+++ b/internal/infrastructure/agents/tools/cromwell/expanded.go
@@ -1,0 +1,23 @@
+package cromwell
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
+)
+
+// fetchExpandedWorkflow loads the fully expanded metadata (subworkflows
+// included) so summaries cover the whole run, not just the top level.
+func fetchExpandedWorkflow(ctx context.Context, fetcher ports.WorkflowMetadataFetcher, workflowID string) (*workflow.Workflow, error) {
+	data, err := fetcher.GetRawMetadataWithOptions(ctx, workflowID, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metadata: %v", err)
+	}
+	wf, err := fetcher.ParseMetadata(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metadata: %v", err)
+	}
+	return wf, nil
+}

--- a/internal/infrastructure/agents/tools/cromwell/failures.go
+++ b/internal/infrastructure/agents/tools/cromwell/failures.go
@@ -1,0 +1,68 @@
+package cromwell
+
+import (
+	"context"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// maxTasksPerGroup caps how many task instances are listed per failure
+// group; the group count still reports the true total.
+const maxTasksPerGroup = 10
+
+// FailuresHandler handles the "failures" action: a compact, deduplicated
+// summary of what failed and why, instead of the full (potentially huge)
+// metadata payload.
+type FailuresHandler struct {
+	fetcher ports.WorkflowMetadataFetcher
+}
+
+// NewFailuresHandler creates a new FailuresHandler.
+func NewFailuresHandler(fetcher ports.WorkflowMetadataFetcher) *FailuresHandler {
+	return &FailuresHandler{fetcher: fetcher}
+}
+
+// Handle implements types.Handler.
+func (h *FailuresHandler) Handle(ctx context.Context, input types.Input) (types.Output, error) {
+	const action = "failures"
+	if input.WorkflowID == "" {
+		return types.NewErrorOutput(action, "workflow_id is required"), nil
+	}
+
+	wf, err := fetchExpandedWorkflow(ctx, h.fetcher, input.WorkflowID)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	summary := wf.CalculateFailureSummary()
+
+	groups := make([]map[string]any, 0, len(summary.Groups))
+	for _, g := range summary.Groups {
+		tasks := make([]map[string]any, 0, min(len(g.Tasks), maxTasksPerGroup))
+		for i, t := range g.Tasks {
+			if i >= maxTasksPerGroup {
+				break
+			}
+			entry := map[string]any{"task": t.Name}
+			if t.Stderr != "" {
+				entry["stderr"] = t.Stderr
+			}
+			tasks = append(tasks, entry)
+		}
+		groups = append(groups, map[string]any{
+			"count":         len(g.Tasks),
+			"error":         g.Sample,
+			"tasks":         tasks,
+			"tasks_omitted": max(0, len(g.Tasks)-maxTasksPerGroup),
+		})
+	}
+
+	return types.NewSuccessOutput(action, map[string]any{
+		"id":           input.WorkflowID,
+		"status":       string(wf.Status),
+		"failed_tasks": summary.FailedTasks,
+		"groups":       groups,
+		"hint":         "use action=read_log with a stderr path (or workflow_id+task) to inspect a failure",
+	}), nil
+}

--- a/internal/infrastructure/agents/tools/cromwell/preemption.go
+++ b/internal/infrastructure/agents/tools/cromwell/preemption.go
@@ -1,0 +1,58 @@
+package cromwell
+
+import (
+	"context"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+// PreemptionHandler handles the "preemption" action: preemption efficiency
+// statistics with the tasks losing the most work to preemptions.
+type PreemptionHandler struct {
+	fetcher ports.WorkflowMetadataFetcher
+}
+
+// NewPreemptionHandler creates a new PreemptionHandler.
+func NewPreemptionHandler(fetcher ports.WorkflowMetadataFetcher) *PreemptionHandler {
+	return &PreemptionHandler{fetcher: fetcher}
+}
+
+// Handle implements types.Handler.
+func (h *PreemptionHandler) Handle(ctx context.Context, input types.Input) (types.Output, error) {
+	const action = "preemption"
+	if input.WorkflowID == "" {
+		return types.NewErrorOutput(action, "workflow_id is required"), nil
+	}
+
+	wf, err := fetchExpandedWorkflow(ctx, h.fetcher, input.WorkflowID)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	s := wf.CalculatePreemptionSummary()
+
+	problematic := make([]map[string]any, 0, len(s.ProblematicTasks))
+	for _, t := range s.ProblematicTasks {
+		problematic = append(problematic, map[string]any{
+			"task":            t.Name,
+			"shards":          t.ShardCount,
+			"attempts":        t.TotalAttempts,
+			"preemptions":     t.TotalPreemptions,
+			"cost_efficiency": round2(t.CostEfficiency),
+			"impact_percent":  round1(t.ImpactPercent),
+		})
+	}
+
+	return types.NewSuccessOutput(action, map[string]any{
+		"id":                 input.WorkflowID,
+		"total_tasks":        s.TotalTasks,
+		"preemptible_tasks":  s.PreemptibleTasks,
+		"total_attempts":     s.TotalAttempts,
+		"total_preemptions":  s.TotalPreemptions,
+		"overall_efficiency": round2(s.OverallEfficiency),
+		"cost_efficiency":    round2(s.CostEfficiency),
+		"cost_unit":          s.CostUnit,
+		"problematic_tasks":  problematic,
+	}), nil
+}

--- a/internal/infrastructure/agents/tools/cromwell/readlog.go
+++ b/internal/infrastructure/agents/tools/cromwell/readlog.go
@@ -1,0 +1,164 @@
+package cromwell
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/gcs"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+const (
+	defaultLogLines = 100
+	maxLogLines     = 500
+	// maxLocalLogSize caps local log reads, mirroring the GCS limit.
+	maxLocalLogSize = 5 * 1024 * 1024
+)
+
+// ReadLogHandler handles the "read_log" action: the tail of a task's stderr
+// or stdout in one call — either from an explicit log path or resolved from
+// workflow_id + task.
+type ReadLogHandler struct {
+	repo ports.WorkflowReader
+}
+
+// NewReadLogHandler creates a new ReadLogHandler.
+func NewReadLogHandler(repo ports.WorkflowReader) *ReadLogHandler {
+	return &ReadLogHandler{repo: repo}
+}
+
+// Handle implements types.Handler.
+func (h *ReadLogHandler) Handle(ctx context.Context, input types.Input) (types.Output, error) {
+	const action = "read_log"
+
+	lines := input.Lines
+	if lines <= 0 {
+		lines = defaultLogLines
+	}
+	if lines > maxLogLines {
+		lines = maxLogLines
+	}
+
+	path := input.Path
+	if path == "" {
+		resolved, err := h.resolveLogPath(ctx, input)
+		if err != nil {
+			return types.NewErrorOutput(action, err.Error()), nil
+		}
+		path = resolved
+	}
+
+	content, err := fetchLog(ctx, path)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	tail, total := tailLines(content, lines)
+	return types.NewSuccessOutput(action, map[string]any{
+		"path":        path,
+		"total_lines": total,
+		"shown_lines": min(lines, total),
+		"truncated":   total > lines,
+		"content":     tail,
+	}), nil
+}
+
+// resolveLogPath finds the log path for workflow_id + task (+ optional
+// shard/stream) using the workflow's log listing. The latest attempt wins:
+// earlier attempts were preempted or retried.
+func (h *ReadLogHandler) resolveLogPath(ctx context.Context, input types.Input) (string, error) {
+	if input.WorkflowID == "" || input.Task == "" {
+		return "", fmt.Errorf("either path, or workflow_id and task, are required")
+	}
+
+	logs, err := h.repo.GetLogs(ctx, input.WorkflowID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list logs: %v", err)
+	}
+
+	entries, callName := matchTaskLogs(logs, input.Task)
+	if len(entries) == 0 {
+		available := make([]string, 0, len(logs))
+		for name := range logs {
+			available = append(available, name)
+		}
+		sort.Strings(available)
+		return "", fmt.Errorf("task %q not found in workflow logs; available: %s (for tasks inside subworkflows, call read_log with the subworkflow's workflow_id or pass the stderr path directly)",
+			input.Task, strings.Join(available, ", "))
+	}
+
+	shard := -1
+	if input.Shard != nil {
+		shard = *input.Shard
+	}
+	var best *workflow.CallLog
+	for i := range entries {
+		e := &entries[i]
+		if e.ShardIndex != shard {
+			continue
+		}
+		if best == nil || e.Attempt > best.Attempt {
+			best = e
+		}
+	}
+	if best == nil {
+		return "", fmt.Errorf("no shard %d for task %q (call name %s)", shard, input.Task, callName)
+	}
+
+	if strings.EqualFold(input.Stream, "stdout") {
+		return best.Stdout, nil
+	}
+	return best.Stderr, nil
+}
+
+// matchTaskLogs finds the log entries for a task by exact call name or by
+// its short name (the part after the workflow prefix).
+func matchTaskLogs(logs map[string][]workflow.CallLog, task string) ([]workflow.CallLog, string) {
+	if entries, ok := logs[task]; ok {
+		return entries, task
+	}
+	for callName, entries := range logs {
+		if strings.EqualFold(callName[strings.LastIndex(callName, ".")+1:], task) {
+			return entries, callName
+		}
+	}
+	return nil, ""
+}
+
+// fetchLog reads a log from GCS (gs:// paths) or the local filesystem
+// (local Cromwell backends).
+func fetchLog(ctx context.Context, path string) (string, error) {
+	if strings.HasPrefix(path, "gs://") {
+		return gcs.Fetch(ctx, path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("log not found: %v", err)
+	}
+	if info.Size() > maxLocalLogSize {
+		return "", fmt.Errorf("log too large: %d bytes (max 5MB); read it outside the chat", info.Size())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read log: %v", err)
+	}
+	return string(data), nil
+}
+
+// tailLines returns the last n lines of content and the total line count.
+func tailLines(content string, n int) (string, int) {
+	trimmed := strings.TrimRight(content, "\n")
+	if trimmed == "" {
+		return "", 0
+	}
+	all := strings.Split(trimmed, "\n")
+	if len(all) <= n {
+		return trimmed, len(all)
+	}
+	return strings.Join(all[len(all)-n:], "\n"), len(all)
+}

--- a/internal/infrastructure/agents/tools/e2e_test.go
+++ b/internal/infrastructure/agents/tools/e2e_test.go
@@ -39,7 +39,7 @@ func TestToolsE2E(t *testing.T) {
 		}
 	}
 
-	registry := tools.NewDefaultRegistry(reader, wdlRepo)
+	registry := tools.NewDefaultRegistry(tools.Deps{Repo: reader, Fetcher: reader, WDLRepo: wdlRepo})
 	ctx := context.Background()
 
 	handle := func(t *testing.T, input types.Input) types.Output {
@@ -70,7 +70,7 @@ func TestToolsE2E(t *testing.T) {
 		t.Logf("query ok: total=%v, using workflow %s", data["total"], workflowID)
 	})
 
-	for _, action := range []string{"status", "metadata", "outputs", "logs"} {
+	for _, action := range []string{"status", "metadata", "outputs", "logs", "failures", "cost", "preemption"} {
 		t.Run(action, func(t *testing.T) {
 			if workflowID == "" {
 				t.Skip("no workflow id available")
@@ -79,6 +79,22 @@ func TestToolsE2E(t *testing.T) {
 			t.Logf("%s ok (data type %T)", action, out.Data)
 		})
 	}
+
+	t.Run("read_log_unknown_task", func(t *testing.T) {
+		// Only the error path (a real task's log may live on GCS without
+		// credentials here): must fail gracefully with the available tasks.
+		if workflowID == "" {
+			t.Skip("no workflow id available")
+		}
+		out, err := registry.Handle(ctx, types.Input{Action: "read_log", WorkflowID: workflowID, Task: "pumbaa-e2e-nonexistent-task"})
+		if err != nil {
+			t.Fatalf("read_log returned transport error: %v", err)
+		}
+		if out.Success {
+			t.Fatalf("read_log of nonexistent task should not succeed")
+		}
+		t.Logf("read_log error path ok: %s", out.Error)
+	})
 
 	t.Run("gcs_download_bad_path", func(t *testing.T) {
 		// Only the error path: must fail gracefully, never panic or succeed.

--- a/internal/infrastructure/agents/tools/factory.go
+++ b/internal/infrastructure/agents/tools/factory.go
@@ -28,7 +28,19 @@ type actionSpec struct {
 	name        string
 	description string
 	requiresWDL bool
-	build       func(repo ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler
+	// requiresFetcher marks actions that need expanded-metadata access and
+	// are skipped when no fetcher is wired (e.g. WDL-only registries).
+	requiresFetcher bool
+	build           func(deps Deps) types.Handler
+}
+
+// Deps carries the external dependencies handlers can draw from. Any of the
+// fields may be nil; actions that need a missing dependency are not
+// registered.
+type Deps struct {
+	Repo    ports.WorkflowReader
+	Fetcher ports.WorkflowMetadataFetcher
+	WDLRepo wdl.Repository
 }
 
 func builtinActions() []actionSpec {
@@ -36,49 +48,80 @@ func builtinActions() []actionSpec {
 		{
 			name:        "query",
 			description: "Search Cromwell workflows. Optional: status (Running, Succeeded, Failed, Submitted, Aborted), name.",
-			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
-				return cromwell.NewQueryHandler(repo)
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewQueryHandler(deps.Repo)
 			},
 		},
 		{
 			name:        "status",
 			description: "Get workflow status. Required: workflow_id.",
-			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
-				return cromwell.NewStatusHandler(repo)
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewStatusHandler(deps.Repo)
 			},
 		},
 		{
 			name:        "metadata",
 			description: "Get workflow metadata (calls, inputs, outputs). Required: workflow_id.",
-			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
-				return cromwell.NewMetadataHandler(repo)
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewMetadataHandler(deps.Repo)
 			},
 		},
 		{
 			name:        "outputs",
 			description: "Get workflow output files. Required: workflow_id.",
-			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
-				return cromwell.NewOutputsHandler(repo)
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewOutputsHandler(deps.Repo)
 			},
 		},
 		{
 			name:        "logs",
 			description: "Get log file paths for debugging. Required: workflow_id.",
-			build: func(repo ports.WorkflowReader, _ wdl.Repository) types.Handler {
-				return cromwell.NewLogsHandler(repo)
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewLogsHandler(deps.Repo)
+			},
+		},
+		{
+			name:            "failures",
+			description:     "Compact summary of what failed and why: root causes deduplicated across shards/subworkflows, with affected tasks and stderr paths. Prefer this over metadata to debug failures. Required: workflow_id.",
+			requiresFetcher: true,
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewFailuresHandler(deps.Fetcher)
+			},
+		},
+		{
+			name:        "read_log",
+			description: "Read the tail of a task's log in one call. Either path (a stderr/stdout path from failures/logs), or workflow_id + task (optional: shard, stream=stderr|stdout, lines<=500).",
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewReadLogHandler(deps.Repo)
+			},
+		},
+		{
+			name:            "cost",
+			description:     "Per-task cost breakdown (subworkflows included): real dollars from VM rates, resource-hour estimates kept separate, most expensive first. Required: workflow_id.",
+			requiresFetcher: true,
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewCostHandler(deps.Fetcher)
+			},
+		},
+		{
+			name:            "preemption",
+			description:     "Preemption efficiency: attempts, preemptions and the tasks losing the most work to preempted VMs. Required: workflow_id.",
+			requiresFetcher: true,
+			build: func(deps Deps) types.Handler {
+				return cromwell.NewPreemptionHandler(deps.Fetcher)
 			},
 		},
 		{
 			name:        "gcs_download",
 			description: "Read file from Google Cloud Storage. Required: path (gs://bucket/file).",
-			build: func(_ ports.WorkflowReader, _ wdl.Repository) types.Handler {
+			build: func(deps Deps) types.Handler {
 				return gcs.NewDownloadHandler()
 			},
 		},
 		{
 			name:        "write_file",
 			description: "Write a text file (e.g. a bash script to reproduce/debug a task locally) into the user's current working directory. Required: path (relative), content. Optional: executable (true for scripts), overwrite (must be true to replace an existing file).",
-			build: func(_ ports.WorkflowReader, _ wdl.Repository) types.Handler {
+			build: func(deps Deps) types.Handler {
 				return localfs.NewWriteHandler()
 			},
 		},
@@ -86,24 +129,24 @@ func builtinActions() []actionSpec {
 			name:        "wdl_list",
 			description: "List all indexed WDL tasks and workflows.",
 			requiresWDL: true,
-			build: func(_ ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler {
-				return wdl.NewListHandler(wdlRepo)
+			build: func(deps Deps) types.Handler {
+				return wdl.NewListHandler(deps.WDLRepo)
 			},
 		},
 		{
 			name:        "wdl_search",
 			description: "Search tasks/workflows by name or command content. Required: query.",
 			requiresWDL: true,
-			build: func(_ ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler {
-				return wdl.NewSearchHandler(wdlRepo)
+			build: func(deps Deps) types.Handler {
+				return wdl.NewSearchHandler(deps.WDLRepo)
 			},
 		},
 		{
 			name:        "wdl_info",
 			description: `Get detailed info about a task or workflow. Required: name, type ("task" or "workflow").`,
 			requiresWDL: true,
-			build: func(_ ports.WorkflowReader, wdlRepo wdl.Repository) types.Handler {
-				return wdl.NewInfoHandler(wdlRepo)
+			build: func(deps Deps) types.Handler {
+				return wdl.NewInfoHandler(deps.WDLRepo)
 			},
 		},
 	}
@@ -113,13 +156,16 @@ func builtinActions() []actionSpec {
 // wdlRepo can be nil if WDL indexing is not configured; WDL actions are then
 // omitted. Callers can Register additional actions on the returned registry
 // before passing it to GetPumbaaTool.
-func NewDefaultRegistry(repo ports.WorkflowReader, wdlRepo wdl.Repository) *Registry {
+func NewDefaultRegistry(deps Deps) *Registry {
 	r := NewRegistry()
 	for _, spec := range builtinActions() {
-		if spec.requiresWDL && wdlRepo == nil {
+		if spec.requiresWDL && deps.WDLRepo == nil {
 			continue
 		}
-		r.Register(spec.name, spec.description, spec.build(repo, wdlRepo))
+		if spec.requiresFetcher && deps.Fetcher == nil {
+			continue
+		}
+		r.Register(spec.name, spec.description, spec.build(deps))
 	}
 	return r
 }
@@ -152,7 +198,7 @@ func GetWDLOnlyTools(wdlRepo wdl.Repository) []tool.Tool {
 	if wdlRepo != nil {
 		for _, spec := range builtinActions() {
 			if spec.requiresWDL {
-				r.Register(spec.name, spec.description, spec.build(nil, wdlRepo))
+				r.Register(spec.name, spec.description, spec.build(Deps{WDLRepo: wdlRepo}))
 			}
 		}
 	}
@@ -166,8 +212,8 @@ func GetWDLOnlyTools(wdlRepo wdl.Repository) []tool.Tool {
 // index repository (nil if not configured). extra is the extension point for
 // adding standalone tools to the agent — each must be an ADK tool exposing
 // Declaration()/Run (e.g. built with functiontool.New).
-func GetAllTools(repo ports.WorkflowReader, wdlRepo wdl.Repository, extra ...tool.Tool) []tool.Tool {
-	registry := NewDefaultRegistry(repo, wdlRepo)
+func GetAllTools(deps Deps, extra ...tool.Tool) []tool.Tool {
+	registry := NewDefaultRegistry(deps)
 	return append([]tool.Tool{GetPumbaaTool(registry)}, extra...)
 }
 

--- a/internal/infrastructure/agents/tools/factory_test.go
+++ b/internal/infrastructure/agents/tools/factory_test.go
@@ -22,7 +22,7 @@ func (stubWDLRepo) GetTask(string) (*wdlindex.IndexedTask, error)               
 func (stubWDLRepo) GetWorkflow(string) (*wdlindex.IndexedWorkflow, error)       { return nil, nil }
 
 func TestNewDefaultRegistryOmitsWDLActionsWithoutRepo(t *testing.T) {
-	r := NewDefaultRegistry(nil, nil)
+	r := NewDefaultRegistry(Deps{})
 
 	for _, action := range []string{"query", "status", "metadata", "outputs", "logs", "gcs_download"} {
 		if _, ok := r.Get(action); !ok {
@@ -37,7 +37,7 @@ func TestNewDefaultRegistryOmitsWDLActionsWithoutRepo(t *testing.T) {
 }
 
 func TestNewDefaultRegistryIncludesWDLActionsWithRepo(t *testing.T) {
-	r := NewDefaultRegistry(nil, stubWDLRepo{})
+	r := NewDefaultRegistry(Deps{WDLRepo: stubWDLRepo{}})
 
 	for _, action := range []string{"wdl_list", "wdl_search", "wdl_info"} {
 		if _, ok := r.Get(action); !ok {
@@ -47,7 +47,7 @@ func TestNewDefaultRegistryIncludesWDLActionsWithRepo(t *testing.T) {
 }
 
 func TestBuildDescriptionListsRegisteredActions(t *testing.T) {
-	r := NewDefaultRegistry(nil, nil)
+	r := NewDefaultRegistry(Deps{})
 	r.Register("custom_action", "Does something custom. Required: foo.", types.HandlerFunc(
 		func(ctx context.Context, input types.Input) (types.Output, error) {
 			return types.Output{}, nil
@@ -75,7 +75,7 @@ func TestSchemaEnumCoversAllRegisteredActions(t *testing.T) {
 
 	// Every action a fully-configured registry exposes must be in the enum,
 	// otherwise providers using the explicit schema (Ollama) reject it.
-	r := NewDefaultRegistry(nil, stubWDLRepo{})
+	r := NewDefaultRegistry(Deps{WDLRepo: stubWDLRepo{}})
 	for _, action := range r.Actions() {
 		if !inEnum[action] {
 			t.Errorf("action %q registered but missing from schema enum", action)
@@ -94,7 +94,7 @@ func TestGetAllToolsAppendsExtras(t *testing.T) {
 		t.Fatalf("failed to build extra tool: %v", err)
 	}
 
-	all := GetAllTools(nil, nil, extra)
+	all := GetAllTools(Deps{}, extra)
 
 	if len(all) != 2 {
 		t.Fatalf("expected pumbaa tool + 1 extra, got %d tools", len(all))
@@ -105,7 +105,7 @@ func TestGetAllToolsAppendsExtras(t *testing.T) {
 }
 
 func TestRegistryHandleUnknownActionListsValidOnes(t *testing.T) {
-	r := NewDefaultRegistry(nil, nil)
+	r := NewDefaultRegistry(Deps{})
 
 	out, err := r.Handle(context.Background(), types.Input{Action: "nope"})
 	if err != nil {

--- a/internal/infrastructure/agents/tools/gcs/download.go
+++ b/internal/infrastructure/agents/tools/gcs/download.go
@@ -99,3 +99,24 @@ func downloadObject(ctx context.Context, client *storage.Client, bucket, object 
 
 	return string(content), attrs, nil
 }
+
+// Fetch reads a gs:// object and returns its content, enforcing the same
+// size limit as the download action. Used by other actions (e.g. read_log)
+// that need GCS content without going through the tool interface.
+func Fetch(ctx context.Context, path string) (string, error) {
+	if !strings.HasPrefix(path, "gs://") {
+		return "", fmt.Errorf("path must start with gs://")
+	}
+	bucket, object, err := parsePath(path)
+	if err != nil {
+		return "", err
+	}
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCS client: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	content, _, err := downloadObject(ctx, client, bucket, object)
+	return content, err
+}

--- a/internal/infrastructure/agents/tools/schema.go
+++ b/internal/infrastructure/agents/tools/schema.go
@@ -56,6 +56,23 @@ func GetParametersSchema() map[string]any {
 				"type":        "integer",
 				"description": "Number of results to return for query action (default: 10)",
 			},
+			"task": map[string]any{
+				"type":        "string",
+				"description": "Task name for read_log (short name or full call name)",
+			},
+			"shard": map[string]any{
+				"type":        "integer",
+				"description": "Scatter shard for read_log (default -1 for non-scattered tasks)",
+			},
+			"stream": map[string]any{
+				"type":        "string",
+				"description": "Log stream for read_log",
+				"enum":        []string{"stderr", "stdout"},
+			},
+			"lines": map[string]any{
+				"type":        "integer",
+				"description": "Tail lines for read_log (default 100, max 500)",
+			},
 		},
 		"required": []string{"action"},
 	}

--- a/internal/infrastructure/agents/tools/tools.go
+++ b/internal/infrastructure/agents/tools/tools.go
@@ -18,7 +18,7 @@
 //
 // Callers building a custom registry can also register ad-hoc actions:
 //
-//	registry := tools.NewDefaultRegistry(repo, nil)
+//	registry := tools.NewDefaultRegistry(tools.Deps{Repo: repo})
 //	registry.Register("my_action", "Does something. Required: foo.", myHandler)
 //	agentTools := []tool.Tool{tools.GetPumbaaTool(registry)}
 //
@@ -29,7 +29,7 @@
 // agent untouched:
 //
 //	myTool, _ := functiontool.New(functiontool.Config{Name: "my_tool", ...}, run)
-//	agentTools := tools.GetAllTools(repo, nil, myTool)
+//	agentTools := tools.GetAllTools(tools.Deps{Repo: repo}, myTool)
 //
 // Example handler:
 //

--- a/internal/infrastructure/agents/tools/types/types.go
+++ b/internal/infrastructure/agents/tools/types/types.go
@@ -40,6 +40,18 @@ type Input struct {
 
 	// Overwrite allows write_file to replace an existing file.
 	Overwrite bool `json:"overwrite,omitempty"`
+
+	// Task is the task name for the read_log action (short or full call name).
+	Task string `json:"task,omitempty"`
+
+	// Shard selects a scatter shard for read_log (default: -1, non-scattered).
+	Shard *int `json:"shard,omitempty"`
+
+	// Stream selects the log stream for read_log: "stderr" (default) or "stdout".
+	Stream string `json:"stream,omitempty"`
+
+	// Lines is how many tail lines read_log returns (default 100, max 500).
+	Lines int `json:"lines,omitempty"`
 }
 
 // Output represents the standardized output for all actions.

--- a/internal/interfaces/cli/handler/chat.go
+++ b/internal/interfaces/cli/handler/chat.go
@@ -70,6 +70,25 @@ status, failures, logs, outputs, or runtime metadata.
   Get log file paths for debugging  
   Required: workflow_id
 
+- action="failures"  
+  Compact root-cause summary of a failed workflow: errors deduplicated
+  across shards/subworkflows, with affected tasks and stderr paths.
+  **Always prefer this over metadata when debugging failures.**  
+  Required: workflow_id
+
+- action="read_log"  
+  Read the tail of a task log in one call  
+  Either: path (stderr/stdout path from failures/logs)  
+  Or: workflow_id, task (optional: shard, stream=stderr|stdout, lines)
+
+- action="cost"  
+  Per-task cost breakdown, most expensive first (subworkflows included)  
+  Required: workflow_id
+
+- action="preemption"  
+  Preemption efficiency and the tasks losing the most work to preemptions  
+  Required: workflow_id
+
 ---
 
 ## 2. Files (Google Cloud Storage)
@@ -118,9 +137,11 @@ Use **only** to understand or explain WDL definitions.
 
 - “Status / failed / logs / outputs?” → **Cromwell**
 - “What does this task do / inputs / command?” → **WDL**
+- “Why did it fail?” → failures → read_log (metadata only as last resort: it can be huge)
+- “Why is it expensive / how many preemptions?” → cost / preemption
 - Failure debugging:
-  1. Cromwell (query → logs)
-  2. GCS (gcs_download)
+  1. failures (grouped root causes + stderr paths)
+  2. read_log (tail of the failing task's stderr)
   3. WDL **only to explain the code**
 
 ---

--- a/internal/interfaces/tui/debug/modal_failure_summary.go
+++ b/internal/interfaces/tui/debug/modal_failure_summary.go
@@ -2,131 +2,43 @@ package debug
 
 import (
 	"fmt"
-	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lmtani/pumbaa/internal/domain/workflow"
 )
-
-// failureGroup aggregates failed tasks sharing the same error signature.
-type failureGroup struct {
-	signature string   // normalized message used for grouping
-	sample    string   // one raw message, shown in the modal
-	tasks     []string // node names, in tree order
-}
-
-// Patterns of run-specific noise stripped from messages before grouping, so
-// the same error across hundreds of shards collapses into one group.
-var (
-	sigUUIDRe    = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
-	sigGCSRe     = regexp.MustCompile(`gs://\S+`)
-	sigPathRe    = regexp.MustCompile(`(/[\w.\-]+){3,}`)
-	sigShardRe   = regexp.MustCompile(`(?i)\b(shard|index|attempt)[ :=]+\d+`)
-	sigLongNumRe = regexp.MustCompile(`\b\d{4,}\b`)
-	sigSpaceRe   = regexp.MustCompile(`\s+`)
-)
-
-// normalizeFailureSignature strips run-specific details (paths, IDs, shard
-// numbers) from a failure message so equivalent errors group together.
-func normalizeFailureSignature(msg string) string {
-	s := sigUUIDRe.ReplaceAllString(msg, "<id>")
-	s = sigGCSRe.ReplaceAllString(s, "<path>")
-	s = sigPathRe.ReplaceAllString(s, "<path>")
-	s = sigShardRe.ReplaceAllString(s, "$1 <n>")
-	s = sigLongNumRe.ReplaceAllString(s, "<n>")
-	s = sigSpaceRe.ReplaceAllString(strings.TrimSpace(s), " ")
-	return s
-}
-
-// rootCauseMessages returns the deepest CausedBy messages of a failure —
-// the actual root causes rather than the "Workflow failed" wrappers.
-func rootCauseMessages(f Failure) []string {
-	if len(f.CausedBy) == 0 {
-		if strings.TrimSpace(f.Message) == "" {
-			return nil
-		}
-		return []string{f.Message}
-	}
-	var msgs []string
-	for _, cause := range f.CausedBy {
-		msgs = append(msgs, rootCauseMessages(cause)...)
-	}
-	if len(msgs) == 0 && strings.TrimSpace(f.Message) != "" {
-		msgs = []string{f.Message}
-	}
-	return msgs
-}
-
-// failureGrouper accumulates failure messages into deduplicated groups.
-type failureGrouper struct {
-	index  map[string]int
-	groups []failureGroup
-}
-
-func newFailureGrouper() *failureGrouper {
-	return &failureGrouper{index: make(map[string]int)}
-}
-
-func (g *failureGrouper) add(taskName, msg string) {
-	sig := normalizeFailureSignature(msg)
-	idx, ok := g.index[sig]
-	if !ok {
-		g.groups = append(g.groups, failureGroup{signature: sig, sample: msg})
-		idx = len(g.groups) - 1
-		g.index[sig] = idx
-	}
-	g.groups[idx].tasks = append(g.groups[idx].tasks, taskName)
-}
-
-// addFailures adds the root causes of a failure list, counting each
-// signature at most once per task.
-func (g *failureGrouper) addFailures(taskName string, failures []Failure) {
-	seen := make(map[string]bool)
-	for _, f := range failures {
-		for _, msg := range rootCauseMessages(f) {
-			sig := normalizeFailureSignature(msg)
-			if seen[sig] {
-				continue
-			}
-			seen[sig] = true
-			g.add(taskName, msg)
-		}
-	}
-}
-
-// sorted returns the groups ordered by task count, largest first.
-func (g *failureGrouper) sorted() []failureGroup {
-	groups := g.groups
-	sort.SliceStable(groups, func(i, j int) bool {
-		return len(groups[i].tasks) > len(groups[j].tasks)
-	})
-	return groups
-}
 
 // collectFailureGroups groups every failed leaf in the tree by error
-// signature. When no failed leaves carry messages, it falls back to the
-// workflow-level failures.
-func collectFailureGroups(root *TreeNode, workflowFailures []Failure) []failureGroup {
-	grouper := newFailureGrouper()
+// signature, using the domain's failure grouping. When no failed leaves
+// carry messages, it falls back to the workflow-level failures.
+func collectFailureGroups(root *TreeNode, workflowFailures []Failure) []workflow.FailureGroup {
+	grouper := workflow.NewFailureGrouper()
 
 	for _, node := range flattenTree(root) {
 		if len(node.Children) > 0 || !isFailedStatus(node.Status) || node.Type == NodeTypeWorkflow {
 			continue
 		}
+		task := workflow.FailureTask{Name: node.Name, ShardIndex: -1}
+		if node.CallData != nil {
+			task.ShardIndex = node.CallData.ShardIndex
+			task.Stderr = node.CallData.Stderr
+		}
 		if node.CallData != nil && len(node.CallData.Failures) > 0 {
-			grouper.addFailures(node.Name, node.CallData.Failures)
+			grouper.AddFailures(task, node.CallData.Failures)
 		} else {
-			grouper.add(node.Name, "(no failure message in metadata)")
+			grouper.Add(task, "(no failure message in metadata)")
 		}
 	}
 
-	if len(grouper.groups) == 0 {
-		grouper.addFailures("(workflow)", workflowFailures)
+	groups := grouper.Sorted()
+	if len(groups) == 0 {
+		grouper.AddFailures(workflow.FailureTask{Name: "(workflow)", ShardIndex: -1}, workflowFailures)
+		groups = grouper.Sorted()
 	}
 
-	return grouper.sorted()
+	return groups
 }
 
 // openFailureSummary opens the aggregated failure summary modal.
@@ -147,20 +59,24 @@ func (m Model) openFailureSummary() (tea.Model, tea.Cmd) {
 
 // formatFailureSummary renders the groups for the modal viewport and as raw
 // text for the clipboard.
-func (m Model) formatFailureSummary(groups []failureGroup) (styled, raw string) {
+func (m Model) formatFailureSummary(groups []workflow.FailureGroup) (styled, raw string) {
 	const maxTasksShown = 5
 	width := m.width - 14
 
 	var sb, rawSB strings.Builder
 	for i, group := range groups {
-		count := len(group.tasks)
+		count := len(group.Tasks)
+		names := make([]string, len(group.Tasks))
+		for j, task := range group.Tasks {
+			names[j] = task.Name
+		}
 
-		header := fmt.Sprintf("%d× %s", count, group.sample)
+		header := fmt.Sprintf("%d× %s", count, group.Sample)
 		sb.WriteString(errorStyle.Render(fmt.Sprintf("✗ %d×", count)) + " " +
-			errorMsgStyle.Render(wrapText(group.sample, width-7)) + "\n")
+			errorMsgStyle.Render(wrapText(group.Sample, width-7)) + "\n")
 		rawSB.WriteString(header + "\n")
 
-		shown := group.tasks
+		shown := names
 		if len(shown) > maxTasksShown {
 			shown = shown[:maxTasksShown]
 		}
@@ -169,7 +85,7 @@ func (m Model) formatFailureSummary(groups []failureGroup) (styled, raw string) 
 			taskLine += fmt.Sprintf(" (+%d more)", extra)
 		}
 		sb.WriteString(mutedStyle.Render(wrapText("  "+taskLine, width)) + "\n")
-		rawSB.WriteString("  " + strings.Join(group.tasks, ", ") + "\n")
+		rawSB.WriteString("  " + strings.Join(names, ", ") + "\n")
 
 		if i < len(groups)-1 {
 			sb.WriteString("\n")

--- a/internal/interfaces/tui/debug/modal_failure_summary_test.go
+++ b/internal/interfaces/tui/debug/modal_failure_summary_test.go
@@ -7,37 +7,6 @@ import (
 	"github.com/lmtani/pumbaa/internal/domain/workflow"
 )
 
-func TestNormalizeFailureSignature(t *testing.T) {
-	a := normalizeFailureSignature(
-		"Task failed (shard 3): exit code 137. See gs://bucket/wf/11111111-2222-3333-4444-555555555555/call-X/shard-3/stderr")
-	b := normalizeFailureSignature(
-		"Task failed (shard 47): exit code 137. See gs://bucket/wf/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/call-X/shard-47/stderr")
-
-	if a != b {
-		t.Errorf("signatures should match:\n a=%q\n b=%q", a, b)
-	}
-
-	c := normalizeFailureSignature("Task failed (shard 3): exit code 1.")
-	if a == c {
-		t.Error("different exit codes should produce different signatures")
-	}
-}
-
-func TestRootCauseMessages(t *testing.T) {
-	f := Failure{
-		Message: "Workflow failed",
-		CausedBy: []Failure{
-			{Message: "Job failed", CausedBy: []Failure{{Message: "OOM killed"}}},
-			{Message: "Disk full"},
-		},
-	}
-
-	msgs := rootCauseMessages(f)
-	if len(msgs) != 2 || msgs[0] != "OOM killed" || msgs[1] != "Disk full" {
-		t.Errorf("rootCauseMessages = %v, want [OOM killed, Disk full]", msgs)
-	}
-}
-
 func TestCollectFailureGroupsDeduplicatesAcrossShards(t *testing.T) {
 	root := &TreeNode{ID: "root", Name: "wf", Type: NodeTypeWorkflow, Status: "Failed", Expanded: true}
 	scatter := &TreeNode{ID: "wf.Scatter", Name: "Scatter", Type: NodeTypeCall, Status: "Failed", Parent: root}
@@ -67,14 +36,14 @@ func TestCollectFailureGroupsDeduplicatesAcrossShards(t *testing.T) {
 		t.Fatalf("got %d groups, want 2: %+v", len(groups), groups)
 	}
 	// Largest group first
-	if len(groups[0].tasks) != 2 {
-		t.Errorf("first group has %d tasks, want 2", len(groups[0].tasks))
+	if len(groups[0].Tasks) != 2 {
+		t.Errorf("first group has %d tasks, want 2", len(groups[0].Tasks))
 	}
-	if !strings.Contains(groups[0].sample, "exit code 137") {
-		t.Errorf("first group sample = %q, want the exit code 137 error", groups[0].sample)
+	if !strings.Contains(groups[0].Sample, "exit code 137") {
+		t.Errorf("first group sample = %q, want the exit code 137 error", groups[0].Sample)
 	}
-	if len(groups[1].tasks) != 1 {
-		t.Errorf("second group has %d tasks, want 1", len(groups[1].tasks))
+	if len(groups[1].Tasks) != 1 {
+		t.Errorf("second group has %d tasks, want 1", len(groups[1].Tasks))
 	}
 }
 
@@ -88,7 +57,7 @@ func TestCollectFailureGroupsFallsBackToWorkflowFailures(t *testing.T) {
 	if len(groups) != 1 {
 		t.Fatalf("got %d groups, want 1", len(groups))
 	}
-	if groups[0].tasks[0] != "(workflow)" {
-		t.Errorf("fallback group task = %q, want (workflow)", groups[0].tasks[0])
+	if groups[0].Tasks[0].Name != "(workflow)" {
+		t.Errorf("fallback group task = %q, want (workflow)", groups[0].Tasks[0].Name)
 	}
 }


### PR DESCRIPTION
## Context and problem

The chat agent helps users operate and debug Cromwell workflows, but its action set stopped at the basics: list workflows, dump status/metadata/outputs, list log paths, read a GCS file. Two consequences hurt in practice:

- **Debugging a failure took many round trips and blew the context.** The agent's only route to a root cause was fetching full metadata — megabytes on subworkflow-heavy runs, far beyond what a model context absorbs — then chaining a separate download for each log path it found.
- **Whole classes of questions were unanswerable.** "Why is this run expensive?", "how much work are preemptions wasting?" — the domain layer can answer both since the recent cost work, but the agent had no access.

## What was done

Four actions were added to the agent's tool, each a thin adapter over existing domain logic:

- **failures** — a compact, deduplicated root-cause summary: equivalent errors across hundreds of shards and subworkflow instances collapse into one group with a sample message, the affected tasks and their stderr paths. The grouping logic (signature normalization, root-cause extraction) is the same one behind the debug screen's failure summary — it was lifted from the TUI into the domain, and the TUI now reuses it, so both surfaces stay consistent by construction. Only a task's final attempt counts as failed; preempted-then-retried attempts are not failures.
- **read_log** — the tail of a task's stderr or stdout in one call. It resolves the path from a workflow and task name (latest attempt wins, shard selectable) or accepts an explicit path — exactly what the failures output provides — and reads both GCS and local-backend logs, with line and size caps so responses stay bounded.
- **cost** — the per-task cost breakdown with subworkflows included: real dollars from VM rates and resource-hour estimates reported as separate figures (never summed), most expensive first, plus the server's authoritative total when the cost endpoint provides one.
- **preemption** — attempts, preemption counts, efficiency, and the tasks losing the most work to preempted VMs.

The agent's system instruction now routes failure debugging through failures → read_log, explicitly steering away from raw metadata dumps. The tool's action table gained a dependencies struct: actions declare what they need (repository, expanded-metadata fetcher, WDL index) and are simply not registered when a dependency is absent, preserving the existing degradation behavior.

## Decisions and rationale

- **Domain first.** The failure summary was implemented as a workflow-domain calculation (like the existing cost and preemption summaries) rather than inside the tool handler, both to respect the layering and because the debug TUI needed the same logic — its private copy was deleted in favor of the shared one.
- **Compact projections over raw payloads.** Every new action returns bounded, purpose-shaped data (task lists capped per group with an omitted-count, log tails capped at 500 lines, costs rounded). Agent efficiency is mostly context economy.
- **Read-only only.** Write operations (abort, submit) were deliberately left out: the chat's agent loop currently runs tools without a confirmation step, and destructive actions should wait until a confirmation UX exists.

## Impacts and risks

- The agent gains four read-only capabilities; existing actions are unchanged. Registry construction now takes the dependencies struct — call sites inside the repository were updated, and the composition root wires the Cromwell client as both repository and metadata fetcher.
- For tasks inside subworkflows, read_log resolution by name needs the subworkflow's own workflow id (Cromwell's log listing does not expand subworkflows); the failures action sidesteps this by handing out direct stderr paths, and the error message explains both routes.
- Merge note: touches the same chat handler region as the prompts-consolidation PR (#50); whichever merges second needs a small rebase.

## How to validate

- Unit tests cover the domain failure grouping (deduplication across subworkflow instances, final-attempt semantics, workflow-level fallback, shard labels) and all four handlers (grouping and stderr hints, unit separation and API total, preemption counts, task resolution, latest-attempt selection, tailing, and the unknown-task error listing what is available).
- The opt-in live suite (`PUMBAA_TOOLS_E2E=1`) now exercises failures, cost and preemption against a real Cromwell, plus read_log's error path.
- Full test suite and lint (enforced by CI) pass.
