### PR TITLE
feat(submit): scaffold inputs from the WDL and preflight before submitting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ compile-time checks); interfaces → ports/domain/application, **zero** infra.
 
 ## Guided submit
 
-`pkg/wdl` owns everything decidable from the WDL + inputs JSON alone
-(`WorkflowInputs`, `ScaffoldInputs`, `CheckInputs` — no IO); the
+`pkg/wdl` owns everything decidable from the WDL + inputs JSON + deps zip
+alone (`WorkflowInputs`, `ScaffoldInputs`, `CheckInputs`, `CheckDependencies`
+— no IO; the last checks imports resolve, transitively, by basename); the
 `PreflightUseCase` adds what needs the outside world (server health, file
 existence via `FileProvider.GetSize`). `submit` runs the same checks before
 sending. Design: `docs/design/guided-submit.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,19 @@ pkg/wdl/                     # WDL parser (ANTLR) — public library
 application → domain; infrastructure implements ports (aliases +
 compile-time checks); interfaces → ports/domain/application, **zero** infra.
 
+## Guided submit
+
+`pkg/wdl` owns everything decidable from the WDL + inputs JSON alone
+(`WorkflowInputs`, `ScaffoldInputs`, `CheckInputs` — no IO); the
+`PreflightUseCase` adds what needs the outside world (server health, file
+existence via `FileProvider.GetSize`). `submit` runs the same checks before
+sending. Design: `docs/design/guided-submit.md`.
+
+Two rules that matter when touching it: a WDL this parser cannot read is a
+**warning**, never a block (Cromwell is the authority), and a path that
+cannot be verified (no credentials) is a warning while a path known to be
+missing (`ports.ErrFileNotFound`) is an error.
+
 ## Domain: ready-made calculations
 
 In `domain/workflow/`, all recurse into loaded subworkflows and anchor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,9 @@ Running tasks at `time.Now()`:
   struct — actions with a missing dependency are simply not registered.
 - Actions: query, status, metadata, outputs, logs, **failures** (root-cause
   summary — prefer over metadata for debugging), **read_log** (stderr/stdout
-  tail), **cost**, **preemption**, gcs_download, write_file, wdl_*.
+  tail), **cost**, **preemption**, **scaffold**/**preflight** (submission prep,
+  read WDL/inputs sandboxed to cwd — pkg `agents/tools/submit`), gcs_download,
+  write_file, wdl_*.
 - No write actions (abort/submit) until the chat has a confirmation UX.
 - Agent prompts live in `internal/prompts` (update them when actions change).
 - Live E2E: `PUMBAA_TOOLS_E2E=1 CROMWELL_HOST=... go test ./internal/infrastructure/agents/tools/ -run TestToolsE2E`

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -81,6 +81,8 @@ func main() {
 			Aliases: []string{"wf"},
 			Usage:   "Workflow operations",
 			Subcommands: []*cli.Command{
+				cont.ScaffoldHandler.Command(),
+				cont.PreflightHandler.Command(),
 				cont.SubmitHandler.Command(),
 				cont.MetadataHandler.Command(),
 				cont.DiffHandler.Command(),

--- a/docs/design/guided-submit.md
+++ b/docs/design/guided-submit.md
@@ -1,0 +1,172 @@
+# Design: guided submit (scaffold + preflight)
+
+Status: implemented (first iteration).
+Audience: contributors. See `features/submit.md` for user documentation.
+
+## Problem
+
+Pumbaa is strong once a run exists — dashboard, watch, failure summary, cost,
+preemption. It is weakest exactly where newcomers spend most of their pain:
+**getting to a correct submission**.
+
+The newcomer's loop today is: receive a WDL, hand-write an `inputs.json`
+without knowing which fields are required or what types they take, guess,
+submit, wait, and get a failure that is about infrastructure (a wrong
+`gs://` path, a missing input) 20 minutes and a few dollars later.
+
+The only guard rail today is `wdl.ValidateInputs`, called by the submit use
+case: it detects missing required inputs and nothing else.
+
+## Goals
+
+1. **Scaffold**: generate an `inputs.json` the user can fill, from the WDL
+   itself — required inputs first, typed placeholders, defaults and
+   `parameter_meta` descriptions surfaced.
+2. **Preflight**: answer "is this submission going to work?" before spending
+   time and money — server reachable, WDL parses, required inputs present,
+   no placeholders left, types plausible, no unknown keys, file paths
+   actually exist.
+3. **Fail in 2 seconds, not 20 minutes**: submit runs the preflight checks
+   automatically.
+
+Non-goals (for this iteration): fixing anything automatically, estimating
+cost (separate design), and exposing these through the chat agent (see
+Follow-ups).
+
+## Why the data is already there
+
+The WDL parser (`pkg/wdl`, ANTLR) already produces everything needed:
+
+- `ast.Workflow.Inputs []*Declaration` — each with `Type` and `Expression`
+  (nil when there is no default).
+- `ast.Type{Base, Optional, ArrayType, MapKey/MapValue, PairLeft/PairRight,
+  NonEmpty}` plus a `String()` renderer.
+- `ast.Workflow.ParameterMeta map[string]any` — the WDL convention for
+  documenting inputs.
+- `pkg/wdl/validate.go` already walks required inputs (`requiredInputNames`)
+  and is already wired into `SubmitUseCase`.
+
+So this feature is mostly *surfacing* knowledge the parser already has.
+
+## Design
+
+### Layering
+
+```
+pkg/wdl/inputs.go          Pure WDL knowledge: extract specs, render the
+                           template, check an inputs JSON against the WDL.
+                           No IO, no network.
+application/workflow/      ScaffoldInputsUseCase, PreflightUseCase:
+  scaffold.go              orchestration + IO through ports
+  preflight.go             (FileProvider, HealthChecker).
+interfaces/cli/handler/    `workflow scaffold`, `workflow preflight`,
+                           shared checklist rendering; submit renders the
+                           same report when it blocks.
+```
+
+The checks that need the outside world (does `gs://…` exist, is Cromwell
+up) live in the use case behind existing ports; everything decidable from
+the WDL and the JSON alone stays in `pkg/wdl` and is trivially testable.
+
+### Scaffold
+
+`WorkflowInputs(source)` returns an ordered `[]InputSpec{Name, Type,
+Optional, Default, Description, Required}`; `Name` is qualified
+(`workflow.input`) as Cromwell expects.
+
+`ScaffoldInputs(source, opts)` renders JSON **preserving declaration order**
+(built by hand, not via a Go map, which would shuffle keys), required inputs
+first:
+
+- Required input → placeholder sentinel: `"<FILL: File — path to reads>"`
+  (type, plus the `parameter_meta` description when present).
+- Optional inputs are omitted by default (the file stays minimal and
+  submit-ready once filled) and included with `--all`, rendered as their
+  default value when it is a literal, `null` otherwise.
+
+The sentinel is deliberately machine-detectable: preflight flags any
+remaining `<FILL:` value, so "I generated the template and submitted it
+unedited" fails instantly with a clear message instead of confusing Cromwell.
+
+### Checks (`CheckInputs`)
+
+Returns findings with two severities — **error** (blocks submit) and
+**warning** (reported, does not block) — plus the list of file-typed values
+for the use case to verify:
+
+| Check | Severity | Rationale |
+|---|---|---|
+| WDL does not parse | warning | Our parser may lag the WDL spec; Cromwell is the authority. Same philosophy as today's `ValidateInputs`, which returns nil on parse failure. |
+| Required input missing | error | Cromwell will reject it. |
+| Value still a `<FILL:` placeholder | error | Template was not filled in. |
+| Clear type mismatch (array where scalar expected, object where string expected, non-number for `Int`…) | error | Cromwell will reject it. |
+| Suspicious type (quoted number for `Int`, `Int` for `Float`) | warning | Cromwell coerces some of these; a false block would be worse than a note. |
+| Key not declared by the workflow | warning | Usually a typo (`sampleName` vs `sample_name`), but subworkflow-qualified keys exist that our parser does not model. |
+
+The type checker is deliberately conservative: it only calls something an
+error when no reasonable coercion exists. Being annoying about a valid
+submission would burn the trust the feature depends on.
+
+### Preflight use case
+
+Runs, in order, and always reports every check (never stops at the first
+failure — the newcomer wants the whole list):
+
+1. **Cromwell server** — `ports.HealthChecker`; skipped when `--skip-server`.
+2. **WDL syntax** — parse via `pkg/wdl`.
+3. **Inputs** — `CheckInputs` findings.
+4. **File paths** — `FileProvider.GetSize` for every `File`-typed value
+   (metadata-only on GCS, no data transfer), concurrently with a small
+   worker cap; skipped with `--skip-paths`.
+
+Path check semantics matter: **not found is an error, anything else is a
+warning**. A user without local GCP credentials must not be blocked from
+submitting to a Cromwell that does have them — "could not verify" is not
+"broken". This requires distinguishing the two, so `ports.ErrFileNotFound`
+is (re)introduced as a sentinel and both storage backends wrap not-found
+errors with it.
+
+### Submit integration
+
+`SubmitUseCase` gains the preflight use case as a dependency and runs it
+(server check skipped — submit is about to contact the server anyway)
+before submitting. On errors it returns a typed `PreflightFailedError`
+carrying the report; the handler renders the same checklist as the
+`preflight` command. `--skip-preflight` bypasses it.
+
+This replaces the narrower `wdl.ValidateInputs` call: same spirit (fail
+before Cromwell does), much wider coverage.
+
+## CLI
+
+```bash
+pumbaa workflow scaffold -w main.wdl                 # template to stdout
+pumbaa workflow scaffold -w main.wdl -o inputs.json  # write + explain
+pumbaa workflow preflight -w main.wdl -i inputs.json # checklist, exit 1 on errors
+pumbaa workflow submit -w main.wdl -i inputs.json    # preflight runs first
+```
+
+`scaffold` without `-o` prints only JSON, so `> inputs.json` works; with
+`-o` it writes the file and prints the input table plus next steps (the
+teaching moment). `--all` includes optional inputs; `--force` overwrites.
+
+## Testing
+
+- `pkg/wdl`: extraction (types, optionality, defaults, `parameter_meta`),
+  scaffold (ordering, placeholders, `--all`, literal defaults), checks (each
+  row of the table above, including the coercions that must *not* be flagged).
+- Application: preflight with fake provider/health (all-green, missing file,
+  not-found path vs unverifiable path, skip flags), submit blocked by
+  preflight errors and bypassed with the flag.
+
+## Follow-ups
+
+- **Agent actions** (`scaffold`/`preflight` in the chat tool): the natural
+  front door for a newcomer, who will ask "what do I need to run this?"
+  rather than discover a CLI flag. Needs the tools to read local WDL files
+  (today `localfs` only writes), so it is its own change.
+- **Cost estimate** in preflight: `ast.Task.Runtime` is already parsed, so a
+  price band and resource sanity checks ("512 GB of memory — typo?") fit
+  naturally as another check. Separate design.
+- **Scatter-aware path checks**: `Array[File]` inputs with thousands of
+  entries are capped today; sampling strategy to be decided.

--- a/docs/design/guided-submit.md
+++ b/docs/design/guided-submit.md
@@ -29,9 +29,9 @@ case: it detects missing required inputs and nothing else.
 3. **Fail in 2 seconds, not 20 minutes**: submit runs the preflight checks
    automatically.
 
-Non-goals (for this iteration): fixing anything automatically, estimating
-cost (separate design), and exposing these through the chat agent (see
-Follow-ups).
+Non-goals (for this iteration): fixing anything automatically and estimating
+cost (separate design). Exposing scaffold/preflight through the chat agent
+was a follow-up, now done (see Follow-ups).
 
 ## Why the data is already there
 
@@ -161,10 +161,12 @@ teaching moment). `--all` includes optional inputs; `--force` overwrites.
 
 ## Follow-ups
 
-- **Agent actions** (`scaffold`/`preflight` in the chat tool): the natural
-  front door for a newcomer, who will ask "what do I need to run this?"
-  rather than discover a CLI flag. Needs the tools to read local WDL files
-  (today `localfs` only writes), so it is its own change.
+- ~~**Agent actions** (`scaffold`/`preflight` in the chat tool)~~ — done. The
+  chat agent can scaffold a template and preflight it, reading local WDL and
+  inputs files sandboxed to the working directory (the shared helper
+  `localfs.ResolveWorkingDirPath`). The agent's preflight skips the server
+  check (it already reaches Cromwell for other actions) and reuses the same
+  pure `wdl.CheckInputs`, so the meaningful logic cannot drift from the CLI.
 - **Cost estimate** in preflight: `ast.Task.Runtime` is already parsed, so a
   price band and resource sanity checks ("512 GB of memory — typo?") fit
   naturally as another check. Separate design.

--- a/docs/design/guided-submit.md
+++ b/docs/design/guided-submit.md
@@ -118,6 +118,14 @@ failure — the newcomer wants the whole list):
 4. **File paths** — `FileProvider.GetSize` for every `File`-typed value
    (metadata-only on GCS, no data transfer), concurrently with a small
    worker cap; skipped with `--skip-paths`.
+5. **Dependencies** — only when a `-d` imports zip is given: every `import`
+   in the main WDL and, transitively, in each WDL inside the zip must
+   resolve to a file present in the zip. `pkg/wdl/CheckDependencies` reads
+   the zip from bytes and matches by basename (the flattening convention
+   `pumbaa bundle` produces, and the most lenient one — a structural
+   difference must not block a valid bundle). A missing import is a hard
+   Cromwell parse failure, so it is an error; a zip that cannot be read is a
+   warning.
 
 Path check semantics matter: **not found is an error, anything else is a
 warning**. A user without local GCP credentials must not be blocked from

--- a/docs/features/chat.md
+++ b/docs/features/chat.md
@@ -101,6 +101,14 @@ Choose your preferred AI backend:
     
     List, search, and inspect your indexed WDL workflows (`PUMBAA_WDL_DIR`)
 
+-   :material-airplane-check: **Prepare a Submission**
+    
+    Scaffold an inputs template from a WDL and preflight it before running
+
+-   :material-alert-circle: **Diagnose Failures**
+    
+    Summarize root causes and read the failing task's log
+
 </div>
 
 !!! info "Streaming"
@@ -182,3 +190,6 @@ export PUMBAA_SESSION_DB=~/.pumbaa/sessions.db
     - "Show me the outputs of workflow xyz-456"
     - "Read gs://bucket/path/to/file.txt"
     - "Query last 5 failed workflows"
+    - "What inputs does main.wdl need?"
+    - "Check my inputs.json against main.wdl before I submit"
+    - "Why did workflow abc-123 fail?"

--- a/docs/features/guided-submit.md
+++ b/docs/features/guided-submit.md
@@ -87,6 +87,7 @@ Alias: `pumbaa wf check`
 |------|:-----:|:--------:|-------------|
 | `--workflow` | `-w` | :material-check: | WDL workflow file |
 | `--inputs` | `-i` | | Inputs JSON file |
+| `--dependencies` | `-d` | | Imports ZIP — checks that every import resolves |
 | `--skip-paths` | | | Do not check that input files exist |
 | `--skip-server` | | | Do not check that Cromwell is reachable |
 
@@ -118,6 +119,7 @@ CI job.
 | Types match declarations | :material-check: | Only clear mismatches; coercible values warn instead |
 | Keys declared by the workflow | | Usually a typo, so a warning |
 | `File` inputs exist | :material-check: | Missing is an error; **unverifiable** (no credentials) is only a warning |
+| Imports resolve in the ZIP | :material-check: | Only when `-d` is given; checks the whole import tree, including transitive imports |
 
 !!! note "Missing vs. unverifiable"
     If a path cannot be checked — no local cloud credentials, for instance —

--- a/docs/features/guided-submit.md
+++ b/docs/features/guided-submit.md
@@ -127,7 +127,16 @@ CI job.
 ## :material-shield-check: Submit runs it for you
 
 `pumbaa workflow submit` runs the same checks before sending anything, so a
-broken submission fails in seconds instead of minutes:
+broken submission fails in seconds instead of minutes. It always reports the
+outcome, so you can see the checks happened:
+
+```text
+✓ Preflight passed.
+✓ Workflow submitted successfully!
+```
+
+When there are non-blocking warnings, the full checklist is shown before the
+submission proceeds; when there are errors, nothing is submitted:
 
 ```text
 ✗ 1 problem(s) must be fixed before this run can start
@@ -136,7 +145,8 @@ broken submission fails in seconds instead of minutes:
 ```
 
 The server check is skipped there (submitting contacts the server anyway).
-Use `--skip-preflight` to bypass the checks entirely.
+Use `--skip-preflight` to bypass the checks entirely (it prints
+`Preflight skipped.` so the bypass is explicit).
 
 ## :material-book-open-variant: See Also
 

--- a/docs/features/guided-submit.md
+++ b/docs/features/guided-submit.md
@@ -1,0 +1,144 @@
+# Prepare a Submission
+
+Start from the workflow's own declarations instead of a blank inputs file, and
+find out whether a run will work **before** spending time and money on it.
+
+<div class="grid cards" markdown>
+
+-   :material-file-document-edit: **Scaffold**
+
+    Generate an inputs template from the WDL, with types and documentation
+
+-   :material-airplane-check: **Preflight**
+
+    Check server, WDL, inputs and file paths before submitting
+
+-   :material-shield-check: **Automatic**
+
+    `submit` runs the checks for you
+
+</div>
+
+## :material-rocket-launch: The flow
+
+```bash
+pumbaa workflow scaffold  -w main.wdl -o inputs.json   # 1. generate
+# ... fill in the placeholders ...
+pumbaa workflow preflight -w main.wdl -i inputs.json   # 2. check
+pumbaa workflow submit    -w main.wdl -i inputs.json   # 3. run (checks again)
+```
+
+## :material-file-document-edit: Scaffold
+
+```bash
+pumbaa workflow scaffold --workflow FILE [OPTIONS]
+```
+
+Alias: `pumbaa wf template`
+
+| Flag | Alias | Required | Description |
+|------|:-----:|:--------:|-------------|
+| `--workflow` | `-w` | :material-check: | WDL workflow file |
+| `--output` | `-o` | | Write to this file instead of stdout |
+| `--all` | | | Include optional inputs, with their defaults |
+| `--force` | | | Overwrite an existing output file |
+
+Required inputs come first, each with a placeholder carrying its type and —
+when the WDL documents it in `parameter_meta` — its description:
+
+```json
+{
+  "AlignReads.reads_fastq": "<FILL: File — Sequencing reads in FASTQ format>",
+  "AlignReads.reference_files": "<FILL: Array[File]+ — Reference genome and its index files>",
+  "AlignReads.sample_name": "<FILL: String — Identifier used to name outputs>"
+}
+```
+
+Optional inputs are left out by default, so the file is minimal and ready to
+submit once filled. Add `--all` to include them with their default values.
+
+With `--output`, the command also prints every input — including the optional
+ones — and the next steps:
+
+```text
+✓ Wrote inputs.json for workflow AlignReads
+
+ INPUT                       TYPE          REQUIRED  DEFAULT  DESCRIPTION
+ AlignReads.reads_fastq      File          yes                Sequencing reads in FASTQ format
+ AlignReads.reference_files  Array[File]+  yes                Reference genome and its index files
+ AlignReads.sample_name      String        yes                Identifier used to name outputs
+ AlignReads.threads          Int           no        4
+ AlignReads.skip_qc          Boolean       no        false
+```
+
+!!! tip "Piping"
+    Without `--output` only the JSON is printed, so
+    `pumbaa workflow scaffold -w main.wdl > inputs.json` works.
+
+## :material-airplane-check: Preflight
+
+```bash
+pumbaa workflow preflight --workflow FILE [OPTIONS]
+```
+
+Alias: `pumbaa wf check`
+
+| Flag | Alias | Required | Description |
+|------|:-----:|:--------:|-------------|
+| `--workflow` | `-w` | :material-check: | WDL workflow file |
+| `--inputs` | `-i` | | Inputs JSON file |
+| `--skip-paths` | | | Do not check that input files exist |
+| `--skip-server` | | | Do not check that Cromwell is reachable |
+
+```text
+Preflight — workflow AlignReads
+─────────────────────────────────────────
+  ✓ Cromwell server  reachable
+  ✓ WDL syntax       workflow AlignReads
+  ⚠ Inputs           worth a look
+      ⚠ AlignReads.threads: is the quoted number "8" where Int is expected
+      ⚠ AlignReads.sampleName: not declared by this workflow — check for a typo
+  ✗ Input files      missing files
+      ✗ AlignReads.reference_files[1]: file does not exist: gs://bucket/ref.fai
+
+✗ 1 problem(s) must be fixed before this run can start (2 warning(s) too)
+```
+
+The command exits non-zero when there are errors, so it can gate a script or
+CI job.
+
+### What is checked
+
+| Check | Blocks? | Notes |
+|---|:---:|---|
+| Cromwell reachable | :material-check: | Skipped with `--skip-server` |
+| WDL parses | | A parse failure is only a warning — Cromwell is the authority |
+| Required inputs present | :material-check: | |
+| Placeholders replaced | :material-check: | Catches "scaffolded and submitted unedited" |
+| Types match declarations | :material-check: | Only clear mismatches; coercible values warn instead |
+| Keys declared by the workflow | | Usually a typo, so a warning |
+| `File` inputs exist | :material-check: | Missing is an error; **unverifiable** (no credentials) is only a warning |
+
+!!! note "Missing vs. unverifiable"
+    If a path cannot be checked — no local cloud credentials, for instance —
+    preflight warns instead of blocking: Cromwell may well have access this
+    machine does not.
+
+## :material-shield-check: Submit runs it for you
+
+`pumbaa workflow submit` runs the same checks before sending anything, so a
+broken submission fails in seconds instead of minutes:
+
+```text
+✗ 1 problem(s) must be fixed before this run can start
+
+ℹ Nothing was submitted. Fix the problems above, or use --skip-preflight to submit anyway.
+```
+
+The server check is skipped there (submitting contacts the server anyway).
+Use `--skip-preflight` to bypass the checks entirely.
+
+## :material-book-open-variant: See Also
+
+- [:material-upload: Submit Workflow](submit.md)
+- [:material-package: Bundle Creation](bundle.md)

--- a/docs/features/submit.md
+++ b/docs/features/submit.md
@@ -26,6 +26,11 @@ pumbaa workflow submit --workflow FILE [OPTIONS]
 
 Alias: `pumbaa wf s`
 
+!!! tip "Never written an inputs file for this workflow?"
+    [Scaffold one from the WDL](guided-submit.md) instead of starting from a
+    blank file. Submit also checks the workflow and its inputs before sending
+    anything, so mistakes surface in seconds rather than minutes.
+
 ## :material-flag: Flags
 
 | Flag | Alias | Required | Description |
@@ -35,6 +40,7 @@ Alias: `pumbaa wf s`
 | `--options` | `-o` | | Options JSON file |
 | `--dependencies` | `-d` | | Dependencies ZIP file |
 | `--label` | `-l` | | Labels (`key=value`) |
+| `--skip-preflight` | | | Submit without checking the workflow and inputs first |
 
 ## :material-lightbulb: Examples
 
@@ -66,7 +72,8 @@ Alias: `pumbaa wf s`
 
 ## :material-file-document: Input File
 
-JSON format matching WDL inputs:
+JSON format matching WDL inputs — generate a template with
+[`workflow scaffold`](guided-submit.md):
 
 ```json
 {
@@ -142,6 +149,7 @@ pumbaa workflow metadata <id>       # CLI metadata
 
 ## :material-book-open-variant: See Also
 
+- [:material-airplane-check: Prepare a Submission](guided-submit.md)
 - [:material-package: Bundle Creation](bundle.md)
 - [:material-view-dashboard: Dashboard](dashboard.md)
 - [:material-bug: Debug View](debug.md)

--- a/internal/application/ports/errors.go
+++ b/internal/application/ports/errors.go
@@ -6,6 +6,15 @@ import (
 	"fmt"
 )
 
+// File storage errors
+var (
+	// ErrFileNotFound reports that a path does not exist. Storage backends
+	// wrap their not-found errors with it so callers can tell "this file is
+	// missing" (the user's problem) from "I could not check" (credentials,
+	// network), which must not be treated the same way.
+	ErrFileNotFound = errors.New("file not found")
+)
+
 // Batch logs errors
 var (
 	// ErrInvalidJobName is returned when the job name is not a valid full resource name.

--- a/internal/application/workflow/preflight.go
+++ b/internal/application/workflow/preflight.go
@@ -1,0 +1,302 @@
+// preflight.go answers "is this submission going to work?" before time and
+// money are spent: server reachable, WDL parseable, inputs complete and
+// plausible, and the file paths they point at actually there.
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/lmtani/pumbaa/internal/application"
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/pkg/wdl"
+)
+
+// pathCheckConcurrency bounds the parallel existence checks: enough to keep
+// a scattered input snappy, small enough to stay polite to the storage API.
+const pathCheckConcurrency = 8
+
+// CheckStatus is the outcome of one preflight check.
+type CheckStatus string
+
+const (
+	CheckOK      CheckStatus = "ok"
+	CheckWarning CheckStatus = "warning"
+	CheckFailed  CheckStatus = "failed"
+	CheckSkipped CheckStatus = "skipped"
+)
+
+// PreflightItem is one problem inside a check.
+type PreflightItem struct {
+	Severity string // "error" blocks the run; "warning" is informational
+	Subject  string // Input name or path the item is about
+	Message  string
+}
+
+// PreflightCheck groups the findings of one aspect of the submission.
+type PreflightCheck struct {
+	Name   string
+	Status CheckStatus
+	Detail string
+	Items  []PreflightItem
+}
+
+// PreflightReport is the full checklist.
+type PreflightReport struct {
+	WorkflowName string
+	Checks       []PreflightCheck
+}
+
+// HasErrors reports whether anything would make the run fail.
+func (r *PreflightReport) HasErrors() bool {
+	for _, c := range r.Checks {
+		if c.Status == CheckFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// Counts returns how many errors and warnings the report holds.
+func (r *PreflightReport) Counts() (errCount, warnCount int) {
+	for _, c := range r.Checks {
+		for _, i := range c.Items {
+			if i.Severity == string(wdl.SeverityError) {
+				errCount++
+			} else {
+				warnCount++
+			}
+		}
+	}
+	return errCount, warnCount
+}
+
+// PreflightFailedError reports that preflight found blocking problems. It
+// carries the report so callers can render the whole checklist instead of a
+// single message.
+type PreflightFailedError struct {
+	Report *PreflightReport
+}
+
+func (e *PreflightFailedError) Error() string {
+	errCount, _ := e.Report.Counts()
+	return fmt.Sprintf("preflight found %d problem(s) that would make this run fail", errCount)
+}
+
+// PreflightUseCase validates a submission before it happens.
+type PreflightUseCase struct {
+	fileProvider ports.FileProvider
+	health       ports.HealthChecker
+}
+
+// NewPreflightUseCase creates a new preflight use case. health may be nil,
+// in which case the server check is skipped.
+func NewPreflightUseCase(fp ports.FileProvider, health ports.HealthChecker) *PreflightUseCase {
+	return &PreflightUseCase{fileProvider: fp, health: health}
+}
+
+// PreflightInput is the input for a preflight run.
+type PreflightInput struct {
+	WorkflowFile string
+	InputsFile   string
+	// SkipServer skips the Cromwell health check (submit does this: it is
+	// about to contact the server anyway).
+	SkipServer bool
+	// SkipPaths skips verifying that File inputs exist.
+	SkipPaths bool
+}
+
+// Execute runs every check and returns the full report. It does not stop at
+// the first failure: the point is to show everything that needs fixing.
+func (uc *PreflightUseCase) Execute(ctx context.Context, input PreflightInput) (*PreflightReport, error) {
+	if input.WorkflowFile == "" {
+		return nil, application.NewInputValidationError("workflowFile", "is required")
+	}
+
+	source, err := uc.fileProvider.ReadBytes(ctx, input.WorkflowFile)
+	if err != nil {
+		return nil, application.NewUseCaseError("preflight", "failed to read workflow file", err)
+	}
+
+	var inputsData []byte
+	if input.InputsFile != "" {
+		inputsData, err = uc.fileProvider.ReadBytes(ctx, input.InputsFile)
+		if err != nil {
+			return nil, application.NewUseCaseError("preflight", "failed to read inputs file", err)
+		}
+	}
+
+	return uc.check(ctx, source, inputsData, input.SkipServer, input.SkipPaths), nil
+}
+
+// check runs the checklist over already-read sources, so callers that hold
+// the bytes (submit) do not read them twice.
+func (uc *PreflightUseCase) check(ctx context.Context, source, inputsData []byte, skipServer, skipPaths bool) *PreflightReport {
+	report := &PreflightReport{}
+	report.Checks = append(report.Checks, uc.checkServer(ctx, skipServer))
+
+	inputsReport := wdl.CheckInputs(source, inputsData)
+	report.WorkflowName = inputsReport.WorkflowName
+	report.Checks = append(report.Checks, syntaxCheck(inputsReport), inputsCheck(inputsReport))
+
+	report.Checks = append(report.Checks, uc.checkPaths(ctx, inputsReport.Files, skipPaths))
+
+	return report
+}
+
+// checkServer reports whether Cromwell is reachable and healthy.
+func (uc *PreflightUseCase) checkServer(ctx context.Context, skip bool) PreflightCheck {
+	check := PreflightCheck{Name: "Cromwell server"}
+	if skip || uc.health == nil {
+		check.Status = CheckSkipped
+		check.Detail = "not checked"
+		return check
+	}
+
+	status, err := uc.health.GetHealthStatus(ctx)
+	switch {
+	case err != nil:
+		check.Status = CheckFailed
+		check.Detail = "unreachable"
+		check.Items = append(check.Items, PreflightItem{
+			Severity: string(wdl.SeverityError),
+			Message:  fmt.Sprintf("could not reach Cromwell: %v — check CROMWELL_HOST", err),
+		})
+	case status != nil && !status.OK:
+		// Degraded subsystems are worth knowing about but do not stop a run.
+		check.Status = CheckWarning
+		check.Detail = "degraded"
+		check.Items = append(check.Items, PreflightItem{
+			Severity: string(wdl.SeverityWarning),
+			Message:  fmt.Sprintf("server reports unhealthy subsystems: %v", status.UnhealthySystems),
+		})
+	default:
+		check.Status = CheckOK
+		check.Detail = "reachable"
+	}
+	return check
+}
+
+// syntaxCheck reports whether the WDL could be parsed locally.
+func syntaxCheck(r *wdl.InputsReport) PreflightCheck {
+	check := PreflightCheck{Name: "WDL syntax"}
+	if r.Parsed {
+		check.Status = CheckOK
+		check.Detail = "workflow " + r.WorkflowName
+		return check
+	}
+	// Never a failure: Cromwell is the authority on WDL this parser cannot read.
+	check.Status = CheckWarning
+	check.Detail = "could not parse locally"
+	for _, f := range r.Findings {
+		check.Items = append(check.Items, PreflightItem{Severity: string(f.Severity), Message: f.Message})
+	}
+	return check
+}
+
+// inputsCheck turns the WDL-level findings into a check.
+func inputsCheck(r *wdl.InputsReport) PreflightCheck {
+	check := PreflightCheck{Name: "Inputs"}
+	if !r.Parsed {
+		check.Status = CheckSkipped
+		check.Detail = "WDL could not be parsed"
+		return check
+	}
+
+	for _, f := range r.Findings {
+		check.Items = append(check.Items, PreflightItem{
+			Severity: string(f.Severity),
+			Subject:  f.Input,
+			Message:  f.Message,
+		})
+	}
+
+	switch {
+	case r.HasErrors():
+		check.Status = CheckFailed
+		check.Detail = "problems found"
+	case len(check.Items) > 0:
+		check.Status = CheckWarning
+		check.Detail = "worth a look"
+	default:
+		check.Status = CheckOK
+		check.Detail = "complete and well-typed"
+	}
+	return check
+}
+
+// checkPaths verifies that every File input points at something that exists.
+// A missing file is the user's problem (error); anything else — no
+// credentials, network trouble — only means we could not check (warning),
+// because Cromwell may well have access this machine does not.
+func (uc *PreflightUseCase) checkPaths(ctx context.Context, files []wdl.FileRef, skip bool) PreflightCheck {
+	check := PreflightCheck{Name: "Input files"}
+	switch {
+	case skip:
+		check.Status = CheckSkipped
+		check.Detail = "not checked"
+		return check
+	case len(files) == 0:
+		check.Status = CheckOK
+		check.Detail = "no file inputs to check"
+		return check
+	}
+
+	items := make([]*PreflightItem, len(files))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(pathCheckConcurrency)
+	for i, ref := range files {
+		i, ref := i, ref
+		g.Go(func() error {
+			if _, err := uc.fileProvider.GetSize(gctx, ref.Path); err != nil {
+				if errors.Is(err, ports.ErrFileNotFound) {
+					items[i] = &PreflightItem{
+						Severity: string(wdl.SeverityError),
+						Subject:  ref.Input,
+						Message:  fmt.Sprintf("file does not exist: %s", ref.Path),
+					}
+					return nil
+				}
+				items[i] = &PreflightItem{
+					Severity: string(wdl.SeverityWarning),
+					Subject:  ref.Input,
+					Message:  fmt.Sprintf("could not verify %s: %v", ref.Path, err),
+				}
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // Individual failures become items; the group itself never errors.
+
+	// Reported in input order, not completion order.
+	for _, item := range items {
+		if item != nil {
+			check.Items = append(check.Items, *item)
+		}
+	}
+
+	switch {
+	case hasSeverity(check.Items, wdl.SeverityError):
+		check.Status = CheckFailed
+		check.Detail = "missing files"
+	case len(check.Items) > 0:
+		check.Status = CheckWarning
+		check.Detail = "some could not be verified"
+	default:
+		check.Status = CheckOK
+		check.Detail = fmt.Sprintf("%d file(s) found", len(files))
+	}
+	return check
+}
+
+func hasSeverity(items []PreflightItem, s wdl.Severity) bool {
+	for _, i := range items {
+		if i.Severity == string(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/application/workflow/preflight.go
+++ b/internal/application/workflow/preflight.go
@@ -107,6 +107,9 @@ type PreflightInput struct {
 	SkipServer bool
 	// SkipPaths skips verifying that File inputs exist.
 	SkipPaths bool
+	// DependenciesFile is an optional imports zip; its contents are checked
+	// against the workflow's imports.
+	DependenciesFile string
 }
 
 // Execute runs every check and returns the full report. It does not stop at
@@ -129,12 +132,20 @@ func (uc *PreflightUseCase) Execute(ctx context.Context, input PreflightInput) (
 		}
 	}
 
-	return uc.check(ctx, source, inputsData, input.SkipServer, input.SkipPaths), nil
+	var depsData []byte
+	if input.DependenciesFile != "" {
+		depsData, err = uc.fileProvider.ReadBytes(ctx, input.DependenciesFile)
+		if err != nil {
+			return nil, application.NewUseCaseError("preflight", "failed to read dependencies file", err)
+		}
+	}
+
+	return uc.check(ctx, source, inputsData, depsData, input.SkipServer, input.SkipPaths), nil
 }
 
 // check runs the checklist over already-read sources, so callers that hold
 // the bytes (submit) do not read them twice.
-func (uc *PreflightUseCase) check(ctx context.Context, source, inputsData []byte, skipServer, skipPaths bool) *PreflightReport {
+func (uc *PreflightUseCase) check(ctx context.Context, source, inputsData, depsData []byte, skipServer, skipPaths bool) *PreflightReport {
 	report := &PreflightReport{}
 	report.Checks = append(report.Checks, uc.checkServer(ctx, skipServer))
 
@@ -143,6 +154,7 @@ func (uc *PreflightUseCase) check(ctx context.Context, source, inputsData []byte
 	report.Checks = append(report.Checks, syntaxCheck(inputsReport), inputsCheck(inputsReport))
 
 	report.Checks = append(report.Checks, uc.checkPaths(ctx, inputsReport.Files, skipPaths))
+	report.Checks = append(report.Checks, dependenciesCheck(source, depsData))
 
 	return report
 }
@@ -299,4 +311,33 @@ func hasSeverity(items []PreflightItem, s wdl.Severity) bool {
 		}
 	}
 	return false
+}
+
+// dependenciesCheck verifies the imports resolve inside the dependencies zip.
+// Skipped when no zip is provided (a self-contained workflow needs none).
+func dependenciesCheck(source, depsData []byte) PreflightCheck {
+	check := PreflightCheck{Name: "Dependencies"}
+	if len(depsData) == 0 {
+		check.Status = CheckSkipped
+		check.Detail = "no dependencies zip"
+		return check
+	}
+
+	report := wdl.CheckDependencies(source, depsData)
+	for _, f := range report.Findings {
+		check.Items = append(check.Items, PreflightItem{Severity: string(f.Severity), Message: f.Message})
+	}
+
+	switch {
+	case report.HasErrors():
+		check.Status = CheckFailed
+		check.Detail = "missing imports"
+	case !report.ZipRead:
+		check.Status = CheckWarning
+		check.Detail = "could not read the zip"
+	default:
+		check.Status = CheckOK
+		check.Detail = fmt.Sprintf("%d file(s), all imports resolve", report.WDLFiles)
+	}
+	return check
 }

--- a/internal/application/workflow/preflight_test.go
+++ b/internal/application/workflow/preflight_test.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -78,8 +80,9 @@ func TestPreflightAllGreen(t *testing.T) {
 		t.Errorf("WorkflowName = %q, want Align", report.WorkflowName)
 	}
 	for _, c := range report.Checks {
-		if c.Status != CheckOK {
-			t.Errorf("check %q = %s (%s), want ok", c.Name, c.Status, c.Detail)
+		// Dependencies is legitimately skipped when no zip is provided.
+		if c.Status != CheckOK && c.Status != CheckSkipped {
+			t.Errorf("check %q = %s (%s), want ok or skipped", c.Name, c.Status, c.Detail)
 		}
 	}
 	errCount, warnCount := report.Counts()
@@ -287,4 +290,106 @@ func TestPreflightUnreadableFilesAreHardErrors(t *testing.T) {
 	if _, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "nope.wdl"}); err == nil {
 		t.Error("a missing workflow file should fail outright, not as a check")
 	}
+}
+
+// makeDepsZip builds an in-memory dependencies zip for preflight tests.
+func makeDepsZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+const depsWDL = `version 1.0
+import "helper.wdl"
+workflow Pipe {
+    input { String sample }
+}
+`
+
+func TestPreflightChecksDependencies(t *testing.T) {
+	t.Run("missing import blocks", func(t *testing.T) {
+		zipData := makeDepsZip(t, map[string]string{"other.wdl": "version 1.0\ntask t {}\n"})
+		fp := &mockFileProvider{
+			readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+				switch path {
+				case "pipe.wdl":
+					return []byte(depsWDL), nil
+				case "inputs.json":
+					return []byte(`{"Pipe.sample": "NA12878"}`), nil
+				case "deps.zip":
+					return zipData, nil
+				}
+				return nil, errors.New("unexpected path: " + path)
+			},
+		}
+		uc := NewPreflightUseCase(fp, nil)
+
+		report, err := uc.Execute(context.Background(), PreflightInput{
+			WorkflowFile:     "pipe.wdl",
+			InputsFile:       "inputs.json",
+			DependenciesFile: "deps.zip",
+		})
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		deps := checkByName(t, report, "Dependencies")
+		if deps.Status != CheckFailed || !report.HasErrors() {
+			t.Errorf("a missing import must fail preflight: %+v", deps)
+		}
+		if len(deps.Items) != 1 || !strings.Contains(deps.Items[0].Message, "helper.wdl") {
+			t.Errorf("the missing import should be named: %+v", deps.Items)
+		}
+	})
+
+	t.Run("complete bundle passes", func(t *testing.T) {
+		zipData := makeDepsZip(t, map[string]string{"helper.wdl": "version 1.0\ntask h {}\n"})
+		fp := &mockFileProvider{
+			readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+				switch path {
+				case "pipe.wdl":
+					return []byte(depsWDL), nil
+				case "deps.zip":
+					return zipData, nil
+				}
+				return nil, errors.New("unexpected path: " + path)
+			},
+		}
+		uc := NewPreflightUseCase(fp, nil)
+
+		report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "pipe.wdl", DependenciesFile: "deps.zip"})
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if s := checkByName(t, report, "Dependencies").Status; s != CheckOK {
+			t.Errorf("a complete bundle should pass, got %s", s)
+		}
+	})
+
+	t.Run("no zip skips the check", func(t *testing.T) {
+		fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`,
+			func(ctx context.Context, path string) (int64, error) { return 1, nil })
+		uc := NewPreflightUseCase(fp, nil)
+
+		report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if s := checkByName(t, report, "Dependencies").Status; s != CheckSkipped {
+			t.Errorf("without a zip the dependencies check should be skipped, got %s", s)
+		}
+	})
 }

--- a/internal/application/workflow/preflight_test.go
+++ b/internal/application/workflow/preflight_test.go
@@ -1,0 +1,290 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	domain "github.com/lmtani/pumbaa/internal/domain/workflow"
+)
+
+// mockHealthChecker is a test double for ports.HealthChecker.
+type mockHealthChecker struct {
+	status *domain.HealthStatus
+	err    error
+}
+
+func (m *mockHealthChecker) GetHealthStatus(ctx context.Context) (*domain.HealthStatus, error) {
+	return m.status, m.err
+}
+
+const preflightWDL = `version 1.0
+
+workflow Align {
+    input {
+        File reads
+        String sample
+        Int threads = 4
+    }
+}
+`
+
+// preflightFiles builds a provider serving the given WDL and inputs, with an
+// optional GetSize behavior for path checks.
+func preflightFiles(wdlSrc, inputs string, getSize func(ctx context.Context, path string) (int64, error)) *mockFileProvider {
+	return &mockFileProvider{
+		readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+			switch path {
+			case "align.wdl":
+				return []byte(wdlSrc), nil
+			case "inputs.json":
+				return []byte(inputs), nil
+			}
+			return nil, errors.New("unexpected path: " + path)
+		},
+		getSizeFunc: getSize,
+	}
+}
+
+func checkByName(t *testing.T, r *PreflightReport, name string) PreflightCheck {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("check %q not found in %+v", name, r.Checks)
+	return PreflightCheck{}
+}
+
+func TestPreflightAllGreen(t *testing.T) {
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`,
+		func(ctx context.Context, path string) (int64, error) { return 42, nil })
+	health := &mockHealthChecker{status: &domain.HealthStatus{OK: true}}
+	uc := NewPreflightUseCase(fp, health)
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if report.HasErrors() {
+		t.Fatalf("a valid submission must pass: %+v", report.Checks)
+	}
+	if report.WorkflowName != "Align" {
+		t.Errorf("WorkflowName = %q, want Align", report.WorkflowName)
+	}
+	for _, c := range report.Checks {
+		if c.Status != CheckOK {
+			t.Errorf("check %q = %s (%s), want ok", c.Name, c.Status, c.Detail)
+		}
+	}
+	errCount, warnCount := report.Counts()
+	if errCount != 0 || warnCount != 0 {
+		t.Errorf("counts = %d errors / %d warnings, want none", errCount, warnCount)
+	}
+}
+
+func TestPreflightReportsEveryProblemAtOnce(t *testing.T) {
+	// Missing required input AND a bad path: a newcomer should see both in
+	// one pass, not one per attempt.
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/missing.fastq"}`,
+		func(ctx context.Context, path string) (int64, error) {
+			return 0, fmt.Errorf("%w: %s", ports.ErrFileNotFound, path)
+		})
+	uc := NewPreflightUseCase(fp, &mockHealthChecker{status: &domain.HealthStatus{OK: true}})
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if !report.HasErrors() {
+		t.Fatal("expected errors")
+	}
+	inputs := checkByName(t, report, "Inputs")
+	if inputs.Status != CheckFailed {
+		t.Errorf("Inputs check = %s, want failed", inputs.Status)
+	}
+	files := checkByName(t, report, "Input files")
+	if files.Status != CheckFailed {
+		t.Errorf("Input files check = %s, want failed", files.Status)
+	}
+	if len(files.Items) != 1 || !strings.Contains(files.Items[0].Message, "does not exist") {
+		t.Errorf("missing file should be reported plainly: %+v", files.Items)
+	}
+	errCount, _ := report.Counts()
+	if errCount != 2 {
+		t.Errorf("expected both problems reported, got %d: %+v", errCount, report.Checks)
+	}
+}
+
+func TestPreflightUnverifiablePathIsAWarning(t *testing.T) {
+	// No local credentials must not block a submission to a Cromwell that
+	// does have them.
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`,
+		func(ctx context.Context, path string) (int64, error) {
+			return 0, errors.New("failed to create GCS client: no credentials found")
+		})
+	uc := NewPreflightUseCase(fp, &mockHealthChecker{status: &domain.HealthStatus{OK: true}})
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if report.HasErrors() {
+		t.Fatalf("an unverifiable path must not block: %+v", report.Checks)
+	}
+	files := checkByName(t, report, "Input files")
+	if files.Status != CheckWarning {
+		t.Errorf("Input files check = %s, want warning", files.Status)
+	}
+	if len(files.Items) != 1 || !strings.Contains(files.Items[0].Message, "could not verify") {
+		t.Errorf("warning should say it could not check: %+v", files.Items)
+	}
+}
+
+func TestPreflightUnreachableServerFails(t *testing.T) {
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`, nil)
+	uc := NewPreflightUseCase(fp, &mockHealthChecker{err: errors.New("connection refused")})
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	server := checkByName(t, report, "Cromwell server")
+	if server.Status != CheckFailed || !report.HasErrors() {
+		t.Errorf("an unreachable server must fail preflight: %+v", server)
+	}
+	if !strings.Contains(server.Items[0].Message, "CROMWELL_HOST") {
+		t.Errorf("the message should point at the fix: %q", server.Items[0].Message)
+	}
+}
+
+func TestPreflightDegradedServerWarns(t *testing.T) {
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`,
+		func(ctx context.Context, path string) (int64, error) { return 1, nil })
+	uc := NewPreflightUseCase(fp, &mockHealthChecker{
+		status: &domain.HealthStatus{OK: false, Degraded: true, UnhealthySystems: []string{"PAPI"}},
+	})
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	server := checkByName(t, report, "Cromwell server")
+	if server.Status != CheckWarning || report.HasErrors() {
+		t.Errorf("a degraded server should warn, not block: %+v", server)
+	}
+}
+
+func TestPreflightSkipFlags(t *testing.T) {
+	called := false
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`,
+		func(ctx context.Context, path string) (int64, error) {
+			called = true
+			return 0, fmt.Errorf("%w: %s", ports.ErrFileNotFound, path)
+		})
+	uc := NewPreflightUseCase(fp, &mockHealthChecker{err: errors.New("connection refused")})
+
+	report, err := uc.Execute(context.Background(), PreflightInput{
+		WorkflowFile: "align.wdl",
+		InputsFile:   "inputs.json",
+		SkipServer:   true,
+		SkipPaths:    true,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if called {
+		t.Error("--skip-paths must not touch storage")
+	}
+	if report.HasErrors() {
+		t.Errorf("both failing checks were skipped: %+v", report.Checks)
+	}
+	if s := checkByName(t, report, "Cromwell server").Status; s != CheckSkipped {
+		t.Errorf("server check = %s, want skipped", s)
+	}
+	if s := checkByName(t, report, "Input files").Status; s != CheckSkipped {
+		t.Errorf("paths check = %s, want skipped", s)
+	}
+}
+
+func TestPreflightWithoutHealthCheckerSkipsServer(t *testing.T) {
+	fp := preflightFiles(preflightWDL, `{"Align.reads": "gs://b/r.fastq", "Align.sample": "NA12878"}`,
+		func(ctx context.Context, path string) (int64, error) { return 1, nil })
+	uc := NewPreflightUseCase(fp, nil)
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if s := checkByName(t, report, "Cromwell server").Status; s != CheckSkipped {
+		t.Errorf("server check = %s, want skipped when no checker is wired", s)
+	}
+}
+
+func TestPreflightUnparseableWDLDoesNotBlock(t *testing.T) {
+	fp := preflightFiles("this is not WDL {{{", `{"whatever": 1}`, nil)
+	uc := NewPreflightUseCase(fp, nil)
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl", InputsFile: "inputs.json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if report.HasErrors() {
+		t.Errorf("Cromwell is the authority on WDL we cannot parse: %+v", report.Checks)
+	}
+	if s := checkByName(t, report, "WDL syntax").Status; s != CheckWarning {
+		t.Errorf("WDL syntax check = %s, want warning", s)
+	}
+	if s := checkByName(t, report, "Inputs").Status; s != CheckSkipped {
+		t.Errorf("Inputs check = %s, want skipped when the WDL is unreadable", s)
+	}
+}
+
+func TestPreflightWithoutInputsFileReportsMissingInputs(t *testing.T) {
+	fp := preflightFiles(preflightWDL, "", nil)
+	uc := NewPreflightUseCase(fp, nil)
+
+	report, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "align.wdl"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if !report.HasErrors() {
+		t.Fatal("a workflow with required inputs and no inputs file cannot run")
+	}
+	errCount, _ := report.Counts()
+	if errCount != 2 {
+		t.Errorf("expected one error per required input, got %d", errCount)
+	}
+}
+
+func TestPreflightRequiresWorkflowFile(t *testing.T) {
+	uc := NewPreflightUseCase(&mockFileProvider{}, nil)
+	if _, err := uc.Execute(context.Background(), PreflightInput{}); err == nil {
+		t.Error("expected an error without a workflow file")
+	}
+}
+
+func TestPreflightUnreadableFilesAreHardErrors(t *testing.T) {
+	fp := &mockFileProvider{
+		readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+			return nil, errors.New("no such file")
+		},
+	}
+	uc := NewPreflightUseCase(fp, nil)
+
+	if _, err := uc.Execute(context.Background(), PreflightInput{WorkflowFile: "nope.wdl"}); err == nil {
+		t.Error("a missing workflow file should fail outright, not as a check")
+	}
+}

--- a/internal/application/workflow/scaffold.go
+++ b/internal/application/workflow/scaffold.go
@@ -1,0 +1,58 @@
+// scaffold.go generates an inputs template from a WDL, so users start from
+// the workflow's own declarations instead of a blank file.
+package workflow
+
+import (
+	"context"
+
+	"github.com/lmtani/pumbaa/internal/application"
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/pkg/wdl"
+)
+
+// ScaffoldInputsUseCase builds an inputs JSON template for a workflow.
+type ScaffoldInputsUseCase struct {
+	fileProvider ports.FileProvider
+}
+
+// NewScaffoldInputsUseCase creates a new scaffold use case.
+func NewScaffoldInputsUseCase(fp ports.FileProvider) *ScaffoldInputsUseCase {
+	return &ScaffoldInputsUseCase{fileProvider: fp}
+}
+
+// ScaffoldInputsInput is the input for scaffolding.
+type ScaffoldInputsInput struct {
+	WorkflowFile string
+	// IncludeOptional adds the optional inputs, rendered with their defaults.
+	IncludeOptional bool
+}
+
+// ScaffoldInputsOutput carries the template and the declarations behind it.
+type ScaffoldInputsOutput struct {
+	WorkflowName string
+	Template     []byte
+	Inputs       []wdl.InputSpec
+}
+
+// Execute reads the WDL and renders its inputs template.
+func (uc *ScaffoldInputsUseCase) Execute(ctx context.Context, input ScaffoldInputsInput) (*ScaffoldInputsOutput, error) {
+	if input.WorkflowFile == "" {
+		return nil, application.NewInputValidationError("workflowFile", "is required")
+	}
+
+	source, err := uc.fileProvider.ReadBytes(ctx, input.WorkflowFile)
+	if err != nil {
+		return nil, application.NewUseCaseError("scaffold_inputs", "failed to read workflow file", err)
+	}
+
+	scaffold, err := wdl.ScaffoldInputs(source, wdl.ScaffoldOptions{IncludeOptional: input.IncludeOptional})
+	if err != nil {
+		return nil, application.NewUseCaseError("scaffold_inputs", "failed to read the workflow's inputs", err)
+	}
+
+	return &ScaffoldInputsOutput{
+		WorkflowName: scaffold.WorkflowName,
+		Template:     scaffold.Template,
+		Inputs:       scaffold.Inputs,
+	}, nil
+}

--- a/internal/application/workflow/scaffold_test.go
+++ b/internal/application/workflow/scaffold_test.go
@@ -1,0 +1,100 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestScaffoldInputsUseCase(t *testing.T) {
+	fp := &mockFileProvider{
+		readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+			if path != "align.wdl" {
+				return nil, errors.New("unexpected path: " + path)
+			}
+			return []byte(preflightWDL), nil
+		},
+	}
+	uc := NewScaffoldInputsUseCase(fp)
+
+	out, err := uc.Execute(context.Background(), ScaffoldInputsInput{WorkflowFile: "align.wdl"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if out.WorkflowName != "Align" {
+		t.Errorf("WorkflowName = %q, want Align", out.WorkflowName)
+	}
+	// Every declared input is described, even the ones kept out of the file.
+	if len(out.Inputs) != 3 {
+		t.Errorf("got %d specs, want 3: %+v", len(out.Inputs), out.Inputs)
+	}
+
+	var template map[string]any
+	if err := json.Unmarshal(out.Template, &template); err != nil {
+		t.Fatalf("template is not valid JSON: %v", err)
+	}
+	// Only the two required inputs; "threads" has a default.
+	if len(template) != 2 {
+		t.Errorf("template = %v, want only the required inputs", template)
+	}
+}
+
+func TestScaffoldInputsUseCaseIncludeOptional(t *testing.T) {
+	fp := &mockFileProvider{
+		readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+			return []byte(preflightWDL), nil
+		},
+	}
+	uc := NewScaffoldInputsUseCase(fp)
+
+	out, err := uc.Execute(context.Background(), ScaffoldInputsInput{WorkflowFile: "align.wdl", IncludeOptional: true})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var template map[string]any
+	if err := json.Unmarshal(out.Template, &template); err != nil {
+		t.Fatalf("template is not valid JSON: %v", err)
+	}
+	if len(template) != 3 {
+		t.Errorf("template = %v, want every input", template)
+	}
+	if template["Align.threads"] != float64(4) {
+		t.Errorf("optional input should carry its default, got %v", template["Align.threads"])
+	}
+}
+
+func TestScaffoldInputsUseCaseErrors(t *testing.T) {
+	t.Run("workflow file is required", func(t *testing.T) {
+		uc := NewScaffoldInputsUseCase(&mockFileProvider{})
+		if _, err := uc.Execute(context.Background(), ScaffoldInputsInput{}); err == nil {
+			t.Error("expected an error without a workflow file")
+		}
+	})
+
+	t.Run("unreadable file", func(t *testing.T) {
+		fp := &mockFileProvider{
+			readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return nil, errors.New("no such file")
+			},
+		}
+		uc := NewScaffoldInputsUseCase(fp)
+		if _, err := uc.Execute(context.Background(), ScaffoldInputsInput{WorkflowFile: "nope.wdl"}); err == nil {
+			t.Error("expected an error for an unreadable workflow file")
+		}
+	})
+
+	t.Run("WDL without a workflow", func(t *testing.T) {
+		fp := &mockFileProvider{
+			readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return []byte("version 1.0\n\ntask alone {\n  command <<< echo hi >>>\n}\n"), nil
+			},
+		}
+		uc := NewScaffoldInputsUseCase(fp)
+		if _, err := uc.Execute(context.Background(), ScaffoldInputsInput{WorkflowFile: "tasks.wdl"}); err == nil {
+			t.Error("scaffolding a task-only WDL should explain there is nothing to scaffold")
+		}
+	})
+}

--- a/internal/application/workflow/submit.go
+++ b/internal/application/workflow/submit.go
@@ -6,18 +6,19 @@ import (
 	"github.com/lmtani/pumbaa/internal/application"
 	"github.com/lmtani/pumbaa/internal/application/ports"
 	workflow2 "github.com/lmtani/pumbaa/internal/domain/workflow"
-	"github.com/lmtani/pumbaa/pkg/wdl"
 )
 
 // SubmitUseCase handles workflow submission.
 type SubmitUseCase struct {
 	submitter    ports.WorkflowSubmitter
 	fileProvider ports.FileProvider
+	preflight    *PreflightUseCase
 }
 
-// NewSubmitUseCase creates a new submit use case.
-func NewSubmitUseCase(submitter ports.WorkflowSubmitter, fileProvider ports.FileProvider) *SubmitUseCase {
-	return &SubmitUseCase{submitter: submitter, fileProvider: fileProvider}
+// NewSubmitUseCase creates a new submit use case. preflight may be nil, in
+// which case submissions are not checked before being sent.
+func NewSubmitUseCase(submitter ports.WorkflowSubmitter, fileProvider ports.FileProvider, preflight *PreflightUseCase) *SubmitUseCase {
+	return &SubmitUseCase{submitter: submitter, fileProvider: fileProvider, preflight: preflight}
 }
 
 // SubmitInput represents the input for workflow submission.
@@ -27,6 +28,9 @@ type SubmitInput struct {
 	OptionsFile      string
 	DependenciesFile string
 	Labels           map[string]string
+	// SkipPreflight submits without checking the workflow and its inputs
+	// first.
+	SkipPreflight bool
 }
 
 // SubmitOutput represents the output of workflow submission.
@@ -71,8 +75,13 @@ func (uc *SubmitUseCase) Execute(ctx context.Context, input SubmitInput) (*Submi
 		}
 	}
 
-	if err := wdl.ValidateInputs(workflowSource, inputsData); err != nil {
-		return nil, application.NewInputValidationError("workflowInputs", err.Error())
+	// Catch what Cromwell would only tell us minutes (and dollars) later.
+	// The server check is skipped: submitting is about to contact it anyway.
+	if uc.preflight != nil && !input.SkipPreflight {
+		report := uc.preflight.check(ctx, workflowSource, inputsData, true, false)
+		if report.HasErrors() {
+			return nil, &PreflightFailedError{Report: report}
+		}
 	}
 
 	req := workflow2.SubmitRequest{

--- a/internal/application/workflow/submit.go
+++ b/internal/application/workflow/submit.go
@@ -83,7 +83,7 @@ func (uc *SubmitUseCase) Execute(ctx context.Context, input SubmitInput) (*Submi
 	// The server check is skipped: submitting is about to contact it anyway.
 	var report *PreflightReport
 	if uc.preflight != nil && !input.SkipPreflight {
-		report = uc.preflight.check(ctx, workflowSource, inputsData, true, false)
+		report = uc.preflight.check(ctx, workflowSource, inputsData, depsData, true, false)
 		if report.HasErrors() {
 			return nil, &PreflightFailedError{Report: report}
 		}

--- a/internal/application/workflow/submit.go
+++ b/internal/application/workflow/submit.go
@@ -37,6 +37,10 @@ type SubmitInput struct {
 type SubmitOutput struct {
 	WorkflowID string
 	Status     string
+	// Preflight is the report of the checks run before submitting, so the
+	// caller can confirm they happened (and surface any warnings). Nil when
+	// preflight was skipped.
+	Preflight *PreflightReport
 }
 
 // Execute submits a workflow to Cromwell.
@@ -77,8 +81,9 @@ func (uc *SubmitUseCase) Execute(ctx context.Context, input SubmitInput) (*Submi
 
 	// Catch what Cromwell would only tell us minutes (and dollars) later.
 	// The server check is skipped: submitting is about to contact it anyway.
+	var report *PreflightReport
 	if uc.preflight != nil && !input.SkipPreflight {
-		report := uc.preflight.check(ctx, workflowSource, inputsData, true, false)
+		report = uc.preflight.check(ctx, workflowSource, inputsData, true, false)
 		if report.HasErrors() {
 			return nil, &PreflightFailedError{Report: report}
 		}
@@ -100,5 +105,6 @@ func (uc *SubmitUseCase) Execute(ctx context.Context, input SubmitInput) (*Submi
 	return &SubmitOutput{
 		WorkflowID: resp.ID,
 		Status:     string(resp.Status),
+		Preflight:  report,
 	}, nil
 }

--- a/internal/application/workflow/submit_test.go
+++ b/internal/application/workflow/submit_test.go
@@ -3,9 +3,11 @@ package workflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/lmtani/pumbaa/internal/application"
+	"github.com/lmtani/pumbaa/internal/application/ports"
 	"github.com/lmtani/pumbaa/internal/domain/workflow"
 )
 
@@ -52,7 +54,7 @@ func TestSubmitUseCase_Execute(t *testing.T) {
 			}
 		},
 	}
-	uc := NewSubmitUseCase(repo, fp)
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 	input := SubmitInput{
 		WorkflowFile:     "test.wdl",
@@ -74,7 +76,7 @@ func TestSubmitUseCase_Execute(t *testing.T) {
 func TestSubmitUseCase_Execute_Validation(t *testing.T) {
 	repo := &mockWorkflowRepository{}
 	fp := &mockFileProvider{}
-	uc := NewSubmitUseCase(repo, fp)
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 	_, err := uc.Execute(context.Background(), SubmitInput{})
 	if err == nil {
@@ -99,7 +101,7 @@ func TestSubmitUseCase_Execute_Error(t *testing.T) {
 			return nil, errors.New("file not found")
 		},
 	}
-	uc := NewSubmitUseCase(repo, fp)
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 	input := SubmitInput{
 		WorkflowFile: "non-existent.wdl",
@@ -158,7 +160,7 @@ func TestSubmitUseCase_Execute_OptionalFileReadErrors(t *testing.T) {
 					return []byte("ok"), nil
 				},
 			}
-			uc := NewSubmitUseCase(repo, fp)
+			uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 			_, err := uc.Execute(context.Background(), tt.input)
 			if err == nil {
@@ -186,7 +188,7 @@ func TestSubmitUseCase_Execute_SubmitError(t *testing.T) {
 			return []byte("workflow test {}"), nil
 		},
 	}
-	uc := NewSubmitUseCase(repo, fp)
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 	input := SubmitInput{WorkflowFile: "test.wdl"}
 	_, err := uc.Execute(context.Background(), input)
@@ -228,7 +230,7 @@ workflow Hello {
 			}
 		},
 	}
-	uc := NewSubmitUseCase(repo, fp)
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 	input := SubmitInput{
 		WorkflowFile: "hello.wdl",
@@ -238,15 +240,24 @@ workflow Hello {
 	if err == nil {
 		t.Fatal("expected error for missing required inputs, got nil")
 	}
-	if !errors.Is(err, application.ErrInvalidInput) {
-		t.Errorf("expected ErrInvalidInput, got %v", err)
+	var preflightErr *PreflightFailedError
+	if !errors.As(err, &preflightErr) {
+		t.Fatalf("expected PreflightFailedError, got %T: %v", err, err)
 	}
-	var inputErr *application.InputValidationError
-	if !errors.As(err, &inputErr) {
-		t.Fatalf("expected InputValidationError, got %T", err)
+	if !preflightErr.Report.HasErrors() {
+		t.Error("report should carry the blocking findings")
 	}
-	if inputErr.Field != "workflowInputs" {
-		t.Errorf("expected field workflowInputs, got %s", inputErr.Field)
+	// The report names the missing input, so the user can fix it in one pass.
+	found := false
+	for _, check := range preflightErr.Report.Checks {
+		for _, item := range check.Items {
+			if item.Subject == "Hello.reference" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("report should point at Hello.reference: %+v", preflightErr.Report.Checks)
 	}
 }
 
@@ -276,7 +287,7 @@ workflow Hello {
 			}
 		},
 	}
-	uc := NewSubmitUseCase(repo, fp)
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
 
 	input := SubmitInput{
 		WorkflowFile: "hello.wdl",
@@ -288,5 +299,87 @@ workflow Hello {
 	}
 	if output.WorkflowID != "wf-123" {
 		t.Errorf("expected WorkflowID wf-123, got %s", output.WorkflowID)
+	}
+}
+
+func TestSubmitUseCase_Execute_PreflightBlocksBadPath(t *testing.T) {
+	wdlContent := `version 1.0
+workflow Hello {
+    input {
+        File reference
+    }
+}
+`
+	submitted := false
+	repo := &mockWorkflowRepository{
+		submitFunc: func(ctx context.Context, req workflow.SubmitRequest) (*workflow.SubmitResponse, error) {
+			submitted = true
+			return &workflow.SubmitResponse{ID: "wf-1", Status: workflow.StatusSubmitted}, nil
+		},
+	}
+	fp := &mockFileProvider{
+		readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+			switch path {
+			case "hello.wdl":
+				return []byte(wdlContent), nil
+			case "inputs.json":
+				return []byte(`{"Hello.reference": "gs://bucket/missing.fa"}`), nil
+			}
+			return nil, errors.New("unexpected path")
+		},
+		getSizeFunc: func(ctx context.Context, path string) (int64, error) {
+			return 0, fmt.Errorf("%w: %s", ports.ErrFileNotFound, path)
+		},
+	}
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
+
+	_, err := uc.Execute(context.Background(), SubmitInput{WorkflowFile: "hello.wdl", InputsFile: "inputs.json"})
+
+	var preflightErr *PreflightFailedError
+	if !errors.As(err, &preflightErr) {
+		t.Fatalf("a missing input file must block the submission, got %v", err)
+	}
+	if submitted {
+		t.Error("nothing should reach Cromwell when preflight fails")
+	}
+}
+
+func TestSubmitUseCase_Execute_SkipPreflight(t *testing.T) {
+	// Same broken submission as above, submitted on purpose.
+	wdlContent := `version 1.0
+workflow Hello {
+    input {
+        File reference
+    }
+}
+`
+	repo := &mockWorkflowRepository{
+		submitFunc: func(ctx context.Context, req workflow.SubmitRequest) (*workflow.SubmitResponse, error) {
+			return &workflow.SubmitResponse{ID: "wf-1", Status: workflow.StatusSubmitted}, nil
+		},
+	}
+	fp := &mockFileProvider{
+		readBytesFunc: func(ctx context.Context, path string) ([]byte, error) {
+			switch path {
+			case "hello.wdl":
+				return []byte(wdlContent), nil
+			case "inputs.json":
+				return []byte(`{}`), nil
+			}
+			return nil, errors.New("unexpected path")
+		},
+	}
+	uc := NewSubmitUseCase(repo, fp, NewPreflightUseCase(fp, nil))
+
+	output, err := uc.Execute(context.Background(), SubmitInput{
+		WorkflowFile:  "hello.wdl",
+		InputsFile:    "inputs.json",
+		SkipPreflight: true,
+	})
+	if err != nil {
+		t.Fatalf("--skip-preflight must bypass the checks, got %v", err)
+	}
+	if output.WorkflowID != "wf-1" {
+		t.Errorf("expected the submission to go through, got %+v", output)
 	}
 }

--- a/internal/application/workflow/submit_test.go
+++ b/internal/application/workflow/submit_test.go
@@ -300,6 +300,14 @@ workflow Hello {
 	if output.WorkflowID != "wf-123" {
 		t.Errorf("expected WorkflowID wf-123, got %s", output.WorkflowID)
 	}
+	// The report comes back on success too, so the caller can confirm the
+	// checks ran instead of leaving them invisible.
+	if output.Preflight == nil {
+		t.Fatal("a successful submit should carry its preflight report")
+	}
+	if output.Preflight.HasErrors() {
+		t.Errorf("a clean submit should have no preflight errors: %+v", output.Preflight.Checks)
+	}
 }
 
 func TestSubmitUseCase_Execute_PreflightBlocksBadPath(t *testing.T) {
@@ -381,5 +389,8 @@ workflow Hello {
 	}
 	if output.WorkflowID != "wf-1" {
 		t.Errorf("expected the submission to go through, got %+v", output)
+	}
+	if output.Preflight != nil {
+		t.Errorf("--skip-preflight should leave no report, got %+v", output.Preflight)
 	}
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -217,9 +217,10 @@ func (c *Container) ChatDependencies(rebuildWDLIndex bool, extraTools ...tool.To
 		return nil, fmt.Errorf("session service initialization failed: %w", err)
 	}
 	agentTools := tools.GetAllTools(tools.Deps{
-		Repo:    c.CromwellClient,
-		Fetcher: c.CromwellClient,
-		WDLRepo: c.initWDLRepository(rebuildWDLIndex),
+		Repo:         c.CromwellClient,
+		Fetcher:      c.CromwellClient,
+		WDLRepo:      c.initWDLRepository(rebuildWDLIndex),
+		FileProvider: storage.NewFileProvider(),
 	}, extraTools...)
 	return &tui.ChatDependencies{LLM: llmModel, Tools: agentTools, SessionSvc: svc}, nil
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -44,6 +44,8 @@ type Container struct {
 
 	// Use cases
 	SubmitUseCase                *workflow.SubmitUseCase
+	PreflightUseCase             *workflow.PreflightUseCase
+	ScaffoldInputsUseCase        *workflow.ScaffoldInputsUseCase
 	MetadataUseCase              *workflow.MetadataUseCase
 	CompareUseCase               *workflow.CompareUseCase
 	AbortUseCase                 *workflow.AbortUseCase
@@ -58,6 +60,8 @@ type Container struct {
 
 	// Handlers
 	SubmitHandler         *handler.SubmitHandler
+	PreflightHandler      *handler.PreflightHandler
+	ScaffoldHandler       *handler.ScaffoldHandler
 	MetadataHandler       *handler.MetadataHandler
 	DiffHandler           *handler.DiffHandler
 	AbortHandler          *handler.AbortHandler
@@ -110,7 +114,9 @@ func New(cfg *config.Config, appVersion string) *Container {
 	c.CloudLoggingRepo = cloudlogging.NewCloudLoggingRepository()
 
 	// Initialize use cases
-	c.SubmitUseCase = workflow.NewSubmitUseCase(c.CromwellClient, fileProvider)
+	c.PreflightUseCase = workflow.NewPreflightUseCase(fileProvider, c.CromwellClient)
+	c.ScaffoldInputsUseCase = workflow.NewScaffoldInputsUseCase(fileProvider)
+	c.SubmitUseCase = workflow.NewSubmitUseCase(c.CromwellClient, fileProvider, c.PreflightUseCase)
 	c.MetadataUseCase = workflow.NewMetadataUseCase(c.CromwellClient)
 	c.CompareUseCase = workflow.NewCompareUseCase(c.CromwellClient)
 	c.AbortUseCase = workflow.NewAbortUseCase(c.CromwellClient)
@@ -143,6 +149,8 @@ func New(cfg *config.Config, appVersion string) *Container {
 
 	// Initialize handlers
 	c.SubmitHandler = handler.NewSubmitHandler(c.SubmitUseCase, c.Presenter)
+	c.PreflightHandler = handler.NewPreflightHandler(c.PreflightUseCase, c.Presenter)
+	c.ScaffoldHandler = handler.NewScaffoldHandler(c.ScaffoldInputsUseCase, c.Presenter)
 	c.MetadataHandler = handler.NewMetadataHandler(c.MetadataUseCase, c.Presenter)
 	c.DiffHandler = handler.NewDiffHandler(c.CompareUseCase, c.Presenter)
 	c.AbortHandler = handler.NewAbortHandler(c.AbortUseCase, c.Presenter)

--- a/internal/infrastructure/agents/tools/e2e_test.go
+++ b/internal/infrastructure/agents/tools/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
 	"github.com/lmtani/pumbaa/internal/infrastructure/cromwell"
+	"github.com/lmtani/pumbaa/internal/infrastructure/storage"
 	"github.com/lmtani/pumbaa/internal/infrastructure/wdlindexer"
 )
 
@@ -39,7 +40,7 @@ func TestToolsE2E(t *testing.T) {
 		}
 	}
 
-	registry := tools.NewDefaultRegistry(tools.Deps{Repo: reader, Fetcher: reader, WDLRepo: wdlRepo})
+	registry := tools.NewDefaultRegistry(tools.Deps{Repo: reader, Fetcher: reader, WDLRepo: wdlRepo, FileProvider: storage.NewFileProvider()})
 	ctx := context.Background()
 
 	handle := func(t *testing.T, input types.Input) types.Output {

--- a/internal/infrastructure/agents/tools/factory.go
+++ b/internal/infrastructure/agents/tools/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/cromwell"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/gcs"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/localfs"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/submit"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
 	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/wdl"
 )
@@ -31,16 +32,20 @@ type actionSpec struct {
 	// requiresFetcher marks actions that need expanded-metadata access and
 	// are skipped when no fetcher is wired (e.g. WDL-only registries).
 	requiresFetcher bool
-	build           func(deps Deps) types.Handler
+	// requiresFileProvider marks actions that read/verify local or cloud
+	// files and are skipped when no file provider is wired.
+	requiresFileProvider bool
+	build                func(deps Deps) types.Handler
 }
 
 // Deps carries the external dependencies handlers can draw from. Any of the
 // fields may be nil; actions that need a missing dependency are not
 // registered.
 type Deps struct {
-	Repo    ports.WorkflowReader
-	Fetcher ports.WorkflowMetadataFetcher
-	WDLRepo wdl.Repository
+	Repo         ports.WorkflowReader
+	Fetcher      ports.WorkflowMetadataFetcher
+	WDLRepo      wdl.Repository
+	FileProvider ports.FileProvider
 }
 
 func builtinActions() []actionSpec {
@@ -78,6 +83,21 @@ func builtinActions() []actionSpec {
 			description: "Get log file paths for debugging. Required: workflow_id.",
 			build: func(deps Deps) types.Handler {
 				return cromwell.NewLogsHandler(deps.Repo)
+			},
+		},
+		{
+			name:        "scaffold",
+			description: "Show a workflow's declared inputs and an inputs-JSON template to fill in. Answers \"what does this workflow need to run?\". Required: workflow_file (a .wdl path in the working directory). Optional: include_optional.",
+			build: func(_ Deps) types.Handler {
+				return submit.NewScaffoldHandler()
+			},
+		},
+		{
+			name:                 "preflight",
+			description:          "Check an inputs JSON against a WDL before submitting: required inputs present, well-typed, and their file paths existing. Required: workflow_file. Optional: inputs_file (both .wdl/.json paths in the working directory).",
+			requiresFileProvider: true,
+			build: func(deps Deps) types.Handler {
+				return submit.NewPreflightHandler(deps.FileProvider)
 			},
 		},
 		{
@@ -163,6 +183,9 @@ func NewDefaultRegistry(deps Deps) *Registry {
 			continue
 		}
 		if spec.requiresFetcher && deps.Fetcher == nil {
+			continue
+		}
+		if spec.requiresFileProvider && deps.FileProvider == nil {
 			continue
 		}
 		r.Register(spec.name, spec.description, spec.build(deps))

--- a/internal/infrastructure/agents/tools/factory_test.go
+++ b/internal/infrastructure/agents/tools/factory_test.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -116,5 +118,51 @@ func TestRegistryHandleUnknownActionListsValidOnes(t *testing.T) {
 	}
 	if !strings.Contains(out.Error, "query") {
 		t.Errorf("error should list valid actions, got: %s", out.Error)
+	}
+}
+
+// stubFileProvider is a no-op ports.FileProvider for registry wiring tests.
+type stubFileProvider struct{}
+
+func (stubFileProvider) Read(context.Context, string) (string, error)      { return "", nil }
+func (stubFileProvider) ReadBytes(context.Context, string) ([]byte, error) { return nil, nil }
+func (stubFileProvider) GetSize(context.Context, string) (int64, error)    { return 0, nil }
+
+func TestScaffoldAlwaysAvailablePreflightNeedsFileProvider(t *testing.T) {
+	// scaffold reads a local WDL and needs nothing else, so it is always on.
+	bare := NewDefaultRegistry(Deps{})
+	if _, ok := bare.Get("scaffold"); !ok {
+		t.Error("scaffold should be registered without any dependency")
+	}
+	if _, ok := bare.Get("preflight"); ok {
+		t.Error("preflight should be omitted without a file provider")
+	}
+
+	withFP := NewDefaultRegistry(Deps{FileProvider: stubFileProvider{}})
+	if _, ok := withFP.Get("preflight"); !ok {
+		t.Error("preflight should be registered when a file provider is wired")
+	}
+}
+
+func TestScaffoldActionDispatchesThroughRegistry(t *testing.T) {
+	dir := t.TempDir()
+	old, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+
+	wdlSrc := "version 1.0\n\nworkflow W {\n  input {\n    File x\n  }\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "w.wdl"), []byte(wdlSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewDefaultRegistry(Deps{})
+	out, err := r.Handle(context.Background(), types.Input{Action: "scaffold", WorkflowFile: "w.wdl"})
+	if err != nil || !out.Success {
+		t.Fatalf("scaffold through the registry failed: err=%v out=%+v", err, out)
+	}
+	if data, ok := out.Data.(map[string]any); !ok || data["workflow"] != "W" {
+		t.Errorf("unexpected scaffold output: %+v", out.Data)
 	}
 }

--- a/internal/infrastructure/agents/tools/localfs/write.go
+++ b/internal/infrastructure/agents/tools/localfs/write.go
@@ -29,7 +29,7 @@ func (h *WriteHandler) Handle(_ context.Context, input types.Input) (types.Outpu
 		return types.NewErrorOutput(action, "content is required"), nil
 	}
 
-	fullPath, err := resolveWorkingDirPath(input.Path)
+	fullPath, err := ResolveWorkingDirPath(input.Path)
 	if err != nil {
 		return types.NewErrorOutput(action, err.Error()), nil
 	}
@@ -66,10 +66,10 @@ func (h *WriteHandler) Handle(_ context.Context, input types.Input) (types.Outpu
 	}), nil
 }
 
-// resolveWorkingDirPath validates that the requested path stays inside the
+// ResolveWorkingDirPath validates that the requested path stays inside the
 // user's current working directory and returns its absolute form. The agent
 // must never write outside the directory pumbaa was launched from.
-func resolveWorkingDirPath(path string) (string, error) {
+func ResolveWorkingDirPath(path string) (string, error) {
 	if strings.TrimSpace(path) == "" {
 		return "", fmt.Errorf("path is required (relative to the current working directory)")
 	}

--- a/internal/infrastructure/agents/tools/schema.go
+++ b/internal/infrastructure/agents/tools/schema.go
@@ -73,6 +73,18 @@ func GetParametersSchema() map[string]any {
 				"type":        "integer",
 				"description": "Tail lines for read_log (default 100, max 500)",
 			},
+			"workflow_file": map[string]any{
+				"type":        "string",
+				"description": "Local WDL path (working directory) for scaffold and preflight",
+			},
+			"inputs_file": map[string]any{
+				"type":        "string",
+				"description": "Local inputs JSON path (working directory) for preflight",
+			},
+			"include_optional": map[string]any{
+				"type":        "boolean",
+				"description": "Include optional inputs in the scaffold template",
+			},
 		},
 		"required": []string{"action"},
 	}

--- a/internal/infrastructure/agents/tools/submit/preflight.go
+++ b/internal/infrastructure/agents/tools/submit/preflight.go
@@ -1,0 +1,123 @@
+package submit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+	"github.com/lmtani/pumbaa/pkg/wdl"
+)
+
+// pathCheckConcurrency bounds the parallel existence checks.
+const pathCheckConcurrency = 8
+
+// PreflightHandler handles the "preflight" action: it checks an inputs JSON
+// against a WDL — required inputs present, well-typed, and their file paths
+// actually existing — so a broken submission is caught in the chat instead
+// of failing on Cromwell minutes later.
+//
+// Unlike the CLI preflight, it does not check server reachability: the agent
+// already talks to Cromwell for other actions, so an unreachable server
+// would surface there.
+type PreflightHandler struct {
+	fileProvider ports.FileProvider
+}
+
+// NewPreflightHandler creates a new PreflightHandler.
+func NewPreflightHandler(fp ports.FileProvider) *PreflightHandler {
+	return &PreflightHandler{fileProvider: fp}
+}
+
+// Handle implements types.Handler.
+func (h *PreflightHandler) Handle(ctx context.Context, input types.Input) (types.Output, error) {
+	const action = "preflight"
+	if input.WorkflowFile == "" {
+		return types.NewErrorOutput(action, "workflow_file is required (a .wdl path in the working directory)"), nil
+	}
+
+	source, err := readWorkingDirFile(input.WorkflowFile)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	var inputsData []byte
+	if input.InputsFile != "" {
+		inputsData, err = readWorkingDirFile(input.InputsFile)
+		if err != nil {
+			return types.NewErrorOutput(action, err.Error()), nil
+		}
+	}
+
+	report := wdl.CheckInputs(source, inputsData)
+
+	findings := make([]map[string]any, 0, len(report.Findings))
+	for _, f := range report.Findings {
+		entry := map[string]any{"severity": string(f.Severity), "message": f.Message}
+		if f.Input != "" {
+			entry["input"] = f.Input
+		}
+		findings = append(findings, entry)
+	}
+
+	missing, unverifiable := h.checkPaths(ctx, report.Files)
+
+	ready := !report.HasErrors() && len(missing) == 0
+	data := map[string]any{
+		"workflow":        report.WorkflowName,
+		"ready":           ready,
+		"parsed":          report.Parsed,
+		"input_findings":  findings,
+		"files_checked":   len(report.Files),
+		"missing_files":   missing,
+		"unverified_file": unverifiable,
+	}
+	if ready {
+		data["hint"] = "looks ready; submit with the CLI: pumbaa workflow submit"
+	} else {
+		data["hint"] = "fix the errors above before submitting"
+	}
+	return types.NewSuccessOutput(action, data), nil
+}
+
+// checkPaths verifies that every File input exists. A path known to be
+// missing is the user's problem (missing); anything else — no credentials,
+// network — only means it could not be checked (unverifiable), since
+// Cromwell may reach what this machine cannot.
+func (h *PreflightHandler) checkPaths(ctx context.Context, files []wdl.FileRef) (missing, unverifiable []string) {
+	if h.fileProvider == nil || len(files) == 0 {
+		return nil, nil
+	}
+
+	type result struct{ missing, unverifiable string }
+	results := make([]result, len(files))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(pathCheckConcurrency)
+	for i, ref := range files {
+		i, ref := i, ref
+		g.Go(func() error {
+			if _, err := h.fileProvider.GetSize(gctx, ref.Path); err != nil {
+				if errors.Is(err, ports.ErrFileNotFound) {
+					results[i].missing = fmt.Sprintf("%s: %s", ref.Input, ref.Path)
+				} else {
+					results[i].unverifiable = fmt.Sprintf("%s: %s", ref.Input, ref.Path)
+				}
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	for _, r := range results {
+		if r.missing != "" {
+			missing = append(missing, r.missing)
+		}
+		if r.unverifiable != "" {
+			unverifiable = append(unverifiable, r.unverifiable)
+		}
+	}
+	return missing, unverifiable
+}

--- a/internal/infrastructure/agents/tools/submit/read.go
+++ b/internal/infrastructure/agents/tools/submit/read.go
@@ -1,0 +1,26 @@
+// Package submit provides agent actions that help prepare a workflow
+// submission: scaffolding an inputs template and preflighting it. Both read
+// local files (the WDL, the inputs JSON) sandboxed to the working directory
+// pumbaa was launched from, the same boundary as write_file.
+package submit
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/localfs"
+)
+
+// readWorkingDirFile reads a file the agent was pointed at, refusing paths
+// that escape the working directory.
+func readWorkingDirFile(path string) ([]byte, error) {
+	full, err := localfs.ResolveWorkingDirPath(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %s: %v", path, err)
+	}
+	return data, nil
+}

--- a/internal/infrastructure/agents/tools/submit/scaffold.go
+++ b/internal/infrastructure/agents/tools/submit/scaffold.go
@@ -1,0 +1,59 @@
+package submit
+
+import (
+	"context"
+
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+	"github.com/lmtani/pumbaa/pkg/wdl"
+)
+
+// ScaffoldHandler handles the "scaffold" action: it reports a workflow's
+// declared inputs and an inputs-JSON template to fill in, so a user can see
+// what a workflow needs before writing anything.
+type ScaffoldHandler struct{}
+
+// NewScaffoldHandler creates a new ScaffoldHandler.
+func NewScaffoldHandler() *ScaffoldHandler {
+	return &ScaffoldHandler{}
+}
+
+// Handle implements types.Handler.
+func (h *ScaffoldHandler) Handle(_ context.Context, input types.Input) (types.Output, error) {
+	const action = "scaffold"
+	if input.WorkflowFile == "" {
+		return types.NewErrorOutput(action, "workflow_file is required (a .wdl path in the working directory)"), nil
+	}
+
+	source, err := readWorkingDirFile(input.WorkflowFile)
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	scaffold, err := wdl.ScaffoldInputs(source, wdl.ScaffoldOptions{IncludeOptional: input.IncludeOptional})
+	if err != nil {
+		return types.NewErrorOutput(action, err.Error()), nil
+	}
+
+	inputs := make([]map[string]any, 0, len(scaffold.Inputs))
+	for _, in := range scaffold.Inputs {
+		entry := map[string]any{
+			"name":     in.Name,
+			"type":     in.Type,
+			"required": in.Required(),
+		}
+		if in.Default != "" {
+			entry["default"] = in.Default
+		}
+		if in.Description != "" {
+			entry["description"] = in.Description
+		}
+		inputs = append(inputs, entry)
+	}
+
+	return types.NewSuccessOutput(action, map[string]any{
+		"workflow": scaffold.WorkflowName,
+		"inputs":   inputs,
+		"template": string(scaffold.Template),
+		"hint":     "fill in the placeholders, then use write_file to save the template and action=preflight to check it",
+	}), nil
+}

--- a/internal/infrastructure/agents/tools/submit/submit_test.go
+++ b/internal/infrastructure/agents/tools/submit/submit_test.go
@@ -1,0 +1,214 @@
+package submit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lmtani/pumbaa/internal/application/ports"
+	"github.com/lmtani/pumbaa/internal/infrastructure/agents/tools/types"
+)
+
+const sampleWDL = `version 1.0
+
+workflow AlignReads {
+    input {
+        File reads
+        String sample
+        Int threads = 4
+    }
+
+    parameter_meta {
+        reads: "FASTQ reads"
+    }
+}
+`
+
+// chdir runs the test inside a fresh working directory, since the actions
+// read files relative to it.
+func chdir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+	return dir
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fakeProvider answers GetSize from a set of known paths; anything else is
+// reported as not found, and paths in errPaths as an unverifiable error.
+type fakeProvider struct {
+	exist    map[string]bool
+	errPaths map[string]bool
+}
+
+func (f *fakeProvider) Read(ctx context.Context, path string) (string, error)      { return "", nil }
+func (f *fakeProvider) ReadBytes(ctx context.Context, path string) ([]byte, error) { return nil, nil }
+func (f *fakeProvider) GetSize(ctx context.Context, path string) (int64, error) {
+	if f.errPaths[path] {
+		return 0, errors.New("no credentials")
+	}
+	if f.exist[path] {
+		return 10, nil
+	}
+	return 0, fmt.Errorf("%w: %s", ports.ErrFileNotFound, path)
+}
+
+func TestScaffoldHandler(t *testing.T) {
+	dir := chdir(t)
+	writeFile(t, dir, "main.wdl", sampleWDL)
+	h := NewScaffoldHandler()
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "scaffold", WorkflowFile: "main.wdl"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	if data["workflow"] != "AlignReads" {
+		t.Errorf("workflow = %v, want AlignReads", data["workflow"])
+	}
+	inputs := data["inputs"].([]map[string]any)
+	if len(inputs) != 3 {
+		t.Fatalf("got %d inputs, want 3", len(inputs))
+	}
+	// Required inputs are marked, documentation is surfaced.
+	if inputs[0]["name"] != "AlignReads.reads" || inputs[0]["required"] != true {
+		t.Errorf("first input = %+v, want required reads", inputs[0])
+	}
+	if inputs[0]["description"] != "FASTQ reads" {
+		t.Errorf("parameter_meta not surfaced: %+v", inputs[0])
+	}
+	// The template holds only the required inputs by default.
+	tpl := data["template"].(string)
+	if tpl == "" || !strings.Contains(tpl, "AlignReads.reads") || strings.Contains(tpl, "AlignReads.threads") {
+		t.Errorf("template should hold required inputs only:\n%s", tpl)
+	}
+}
+
+func TestScaffoldHandlerErrors(t *testing.T) {
+	chdir(t)
+	h := NewScaffoldHandler()
+
+	t.Run("workflow_file required", func(t *testing.T) {
+		out, _ := h.Handle(context.Background(), types.Input{Action: "scaffold"})
+		if out.Success {
+			t.Error("missing workflow_file should fail")
+		}
+	})
+
+	t.Run("path escaping the working directory is refused", func(t *testing.T) {
+		out, _ := h.Handle(context.Background(), types.Input{Action: "scaffold", WorkflowFile: "../secret.wdl"})
+		if out.Success {
+			t.Error("a path outside the working directory must be refused")
+		}
+	})
+
+	t.Run("absolute path is refused", func(t *testing.T) {
+		out, _ := h.Handle(context.Background(), types.Input{Action: "scaffold", WorkflowFile: "/etc/passwd"})
+		if out.Success {
+			t.Error("an absolute path must be refused")
+		}
+	})
+}
+
+func TestPreflightHandlerReady(t *testing.T) {
+	dir := chdir(t)
+	writeFile(t, dir, "main.wdl", sampleWDL)
+	writeFile(t, dir, "inputs.json", `{"AlignReads.reads": "gs://b/r.fastq", "AlignReads.sample": "NA12878"}`)
+	fp := &fakeProvider{exist: map[string]bool{"gs://b/r.fastq": true}}
+	h := NewPreflightHandler(fp)
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "preflight", WorkflowFile: "main.wdl", InputsFile: "inputs.json"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	if data["ready"] != true {
+		t.Errorf("ready = %v, want true: %+v", data["ready"], data)
+	}
+	if data["files_checked"] != 1 {
+		t.Errorf("files_checked = %v, want 1", data["files_checked"])
+	}
+}
+
+func TestPreflightHandlerReportsProblems(t *testing.T) {
+	dir := chdir(t)
+	writeFile(t, dir, "main.wdl", sampleWDL)
+	// Missing required "sample", and a reads path that does not exist.
+	writeFile(t, dir, "inputs.json", `{"AlignReads.reads": "gs://b/missing.fastq"}`)
+	fp := &fakeProvider{exist: map[string]bool{}}
+	h := NewPreflightHandler(fp)
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "preflight", WorkflowFile: "main.wdl", InputsFile: "inputs.json"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	if data["ready"] != false {
+		t.Errorf("ready = %v, want false", data["ready"])
+	}
+	missing := data["missing_files"].([]string)
+	if len(missing) != 1 {
+		t.Errorf("missing_files = %v, want the one bad path", missing)
+	}
+	findings := data["input_findings"].([]map[string]any)
+	foundMissing := false
+	for _, f := range findings {
+		if f["input"] == "AlignReads.sample" && f["severity"] == "error" {
+			foundMissing = true
+		}
+	}
+	if !foundMissing {
+		t.Errorf("missing required input should be a finding: %+v", findings)
+	}
+}
+
+func TestPreflightHandlerUnverifiablePathNotFatal(t *testing.T) {
+	dir := chdir(t)
+	writeFile(t, dir, "main.wdl", sampleWDL)
+	writeFile(t, dir, "inputs.json", `{"AlignReads.reads": "gs://b/r.fastq", "AlignReads.sample": "NA12878"}`)
+	fp := &fakeProvider{errPaths: map[string]bool{"gs://b/r.fastq": true}}
+	h := NewPreflightHandler(fp)
+
+	out, err := h.Handle(context.Background(), types.Input{Action: "preflight", WorkflowFile: "main.wdl", InputsFile: "inputs.json"})
+	if err != nil || !out.Success {
+		t.Fatalf("Handle failed: err=%v out=%+v", err, out)
+	}
+
+	data := out.Data.(map[string]any)
+	// A path we could not check does not block readiness.
+	if data["ready"] != true {
+		t.Errorf("an unverifiable path must not block: %+v", data)
+	}
+	if len(data["unverified_file"].([]string)) != 1 {
+		t.Errorf("the unverifiable path should be reported: %+v", data["unverified_file"])
+	}
+}
+
+func TestPreflightHandlerWorkflowFileRequired(t *testing.T) {
+	chdir(t)
+	h := NewPreflightHandler(&fakeProvider{})
+	out, _ := h.Handle(context.Background(), types.Input{Action: "preflight"})
+	if out.Success {
+		t.Error("missing workflow_file should fail")
+	}
+}

--- a/internal/infrastructure/agents/tools/types/types.go
+++ b/internal/infrastructure/agents/tools/types/types.go
@@ -52,6 +52,15 @@ type Input struct {
 
 	// Lines is how many tail lines read_log returns (default 100, max 500).
 	Lines int `json:"lines,omitempty"`
+
+	// WorkflowFile is the local WDL path for the scaffold and preflight actions.
+	WorkflowFile string `json:"workflow_file,omitempty"`
+
+	// InputsFile is the local inputs JSON path for the preflight action.
+	InputsFile string `json:"inputs_file,omitempty"`
+
+	// IncludeOptional adds optional inputs to the scaffold template.
+	IncludeOptional bool `json:"include_optional,omitempty"`
 }
 
 // Output represents the standardized output for all actions.

--- a/internal/infrastructure/storage/gcs_backend.go
+++ b/internal/infrastructure/storage/gcs_backend.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -101,6 +102,9 @@ func (g *GCSBackend) GetSize(ctx context.Context, path string) (int64, error) {
 
 	attrs, err := client.Bucket(bucket).Object(object).Attrs(ctx)
 	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return 0, fmt.Errorf("%w: %s", ports.ErrFileNotFound, path)
+		}
 		return 0, fmt.Errorf("failed to get object attributes: %w", err)
 	}
 

--- a/internal/infrastructure/storage/local_backend.go
+++ b/internal/infrastructure/storage/local_backend.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -55,6 +57,9 @@ func (l *LocalBackend) ReadBytes(_ context.Context, path string) ([]byte, error)
 func (l *LocalBackend) GetSize(_ context.Context, path string) (int64, error) {
 	info, err := os.Stat(path)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, fmt.Errorf("%w: %s", ports.ErrFileNotFound, path)
+		}
 		return 0, fmt.Errorf("failed to stat file: %w", err)
 	}
 	return info.Size(), nil

--- a/internal/interfaces/cli/handler/preflight.go
+++ b/internal/interfaces/cli/handler/preflight.go
@@ -42,6 +42,11 @@ func (h *PreflightHandler) Command() *cli.Command {
 				Aliases: []string{"i"},
 				Usage:   "[optional] Path to the inputs JSON file",
 			},
+			&cli.StringFlag{
+				Name:    "dependencies",
+				Aliases: []string{"d"},
+				Usage:   "[optional] Path to the dependencies ZIP; its imports are checked",
+			},
 			&cli.BoolFlag{
 				Name:  "skip-paths",
 				Usage: "[optional] Do not check that input files exist",
@@ -57,10 +62,11 @@ func (h *PreflightHandler) Command() *cli.Command {
 
 func (h *PreflightHandler) handle(c *cli.Context) error {
 	report, err := h.useCase.Execute(context.Background(), workflow.PreflightInput{
-		WorkflowFile: c.String("workflow"),
-		InputsFile:   c.String("inputs"),
-		SkipPaths:    c.Bool("skip-paths"),
-		SkipServer:   c.Bool("skip-server"),
+		WorkflowFile:     c.String("workflow"),
+		InputsFile:       c.String("inputs"),
+		DependenciesFile: c.String("dependencies"),
+		SkipPaths:        c.Bool("skip-paths"),
+		SkipServer:       c.Bool("skip-server"),
 	})
 	if err != nil {
 		return err

--- a/internal/interfaces/cli/handler/preflight.go
+++ b/internal/interfaces/cli/handler/preflight.go
@@ -1,0 +1,139 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/lmtani/pumbaa/internal/application/workflow"
+	"github.com/lmtani/pumbaa/internal/interfaces/cli/presenter"
+)
+
+// PreflightHandler handles the pre-submission check command.
+type PreflightHandler struct {
+	useCase   *workflow.PreflightUseCase
+	presenter *presenter.Presenter
+}
+
+// NewPreflightHandler creates a new PreflightHandler.
+func NewPreflightHandler(uc *workflow.PreflightUseCase, p *presenter.Presenter) *PreflightHandler {
+	return &PreflightHandler{useCase: uc, presenter: p}
+}
+
+// Command returns the CLI command for preflight checks.
+func (h *PreflightHandler) Command() *cli.Command {
+	return &cli.Command{
+		Name:    "preflight",
+		Aliases: []string{"check"},
+		Usage:   "Check a workflow and its inputs before submitting",
+		Description: "Verifies that Cromwell is reachable, the WDL parses, every required input is\n" +
+			"present and well-typed, and the files the inputs point at exist — so a broken\n" +
+			"submission fails in seconds instead of minutes.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "workflow",
+				Aliases:  []string{"w"},
+				Usage:    "[required] Path to the WDL workflow file",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "inputs",
+				Aliases: []string{"i"},
+				Usage:   "[optional] Path to the inputs JSON file",
+			},
+			&cli.BoolFlag{
+				Name:  "skip-paths",
+				Usage: "[optional] Do not check that input files exist",
+			},
+			&cli.BoolFlag{
+				Name:  "skip-server",
+				Usage: "[optional] Do not check that Cromwell is reachable",
+			},
+		},
+		Action: h.handle,
+	}
+}
+
+func (h *PreflightHandler) handle(c *cli.Context) error {
+	report, err := h.useCase.Execute(context.Background(), workflow.PreflightInput{
+		WorkflowFile: c.String("workflow"),
+		InputsFile:   c.String("inputs"),
+		SkipPaths:    c.Bool("skip-paths"),
+		SkipServer:   c.Bool("skip-server"),
+	})
+	if err != nil {
+		return err
+	}
+
+	renderPreflightReport(h.presenter, report)
+
+	if report.HasErrors() {
+		// Non-zero exit so scripts and CI can gate on it.
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+// renderPreflightReport prints the checklist. Shared with the submit handler,
+// which shows the same report when it refuses to submit.
+func renderPreflightReport(p *presenter.Presenter, r *workflow.PreflightReport) {
+	title := "Preflight"
+	if r.WorkflowName != "" {
+		title += " — workflow " + r.WorkflowName
+	}
+	p.Title(title)
+
+	for _, check := range r.Checks {
+		p.Print("  %s %-16s %s\n", checkSymbol(check.Status), check.Name, check.Detail)
+		for _, item := range check.Items {
+			p.Print("      %s %s\n", itemSymbol(item.Severity), itemText(item))
+		}
+	}
+
+	errCount, warnCount := r.Counts()
+	p.Newline()
+	switch {
+	case errCount > 0:
+		p.Error("%d problem(s) must be fixed before this run can start%s", errCount, warnSuffix(warnCount))
+	case warnCount > 0:
+		p.Warning("ready to submit, with %d warning(s) worth a look", warnCount)
+	default:
+		p.Success("ready to submit")
+	}
+}
+
+// itemText prefixes the message with the input or path it is about.
+func itemText(item workflow.PreflightItem) string {
+	if item.Subject == "" {
+		return item.Message
+	}
+	return fmt.Sprintf("%s: %s", item.Subject, item.Message)
+}
+
+func checkSymbol(status workflow.CheckStatus) string {
+	switch status {
+	case workflow.CheckOK:
+		return "✓"
+	case workflow.CheckWarning:
+		return "⚠"
+	case workflow.CheckFailed:
+		return "✗"
+	default:
+		return "·"
+	}
+}
+
+func itemSymbol(severity string) string {
+	if severity == "error" {
+		return "✗"
+	}
+	return "⚠"
+}
+
+func warnSuffix(warnCount int) string {
+	if warnCount == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (%d warning(s) too)", warnCount)
+}

--- a/internal/interfaces/cli/handler/scaffold.go
+++ b/internal/interfaces/cli/handler/scaffold.go
@@ -1,0 +1,139 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/lmtani/pumbaa/internal/application/workflow"
+	"github.com/lmtani/pumbaa/internal/interfaces/cli/presenter"
+	"github.com/lmtani/pumbaa/pkg/wdl"
+)
+
+// ScaffoldHandler handles the inputs template command.
+type ScaffoldHandler struct {
+	useCase   *workflow.ScaffoldInputsUseCase
+	presenter *presenter.Presenter
+}
+
+// NewScaffoldHandler creates a new ScaffoldHandler.
+func NewScaffoldHandler(uc *workflow.ScaffoldInputsUseCase, p *presenter.Presenter) *ScaffoldHandler {
+	return &ScaffoldHandler{useCase: uc, presenter: p}
+}
+
+// Command returns the CLI command for scaffolding an inputs file.
+func (h *ScaffoldHandler) Command() *cli.Command {
+	return &cli.Command{
+		Name:    "scaffold",
+		Aliases: []string{"template"},
+		Usage:   "Generate an inputs JSON template from a WDL",
+		Description: "Reads the workflow's own declarations and writes an inputs file to fill in:\n" +
+			"required inputs first, each with its type and documentation. Without --output\n" +
+			"the template goes to stdout, so it can be redirected to a file.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "workflow",
+				Aliases:  []string{"w"},
+				Usage:    "[required] Path to the WDL workflow file",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Usage:   "[optional] Write the template to this file instead of stdout",
+			},
+			&cli.BoolFlag{
+				Name:  "all",
+				Usage: "[optional] Include optional inputs, with their default values",
+			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "[optional] Overwrite the output file if it already exists",
+			},
+		},
+		Action: h.handle,
+	}
+}
+
+func (h *ScaffoldHandler) handle(c *cli.Context) error {
+	workflowFile := c.String("workflow")
+	outputFile := c.String("output")
+
+	output, err := h.useCase.Execute(context.Background(), workflow.ScaffoldInputsInput{
+		WorkflowFile:    workflowFile,
+		IncludeOptional: c.Bool("all"),
+	})
+	if err != nil {
+		return err
+	}
+
+	// No destination: the template is the output, so it can be piped.
+	if outputFile == "" {
+		h.presenter.Print("%s", output.Template)
+		return nil
+	}
+
+	if err := writeTemplate(outputFile, output.Template, c.Bool("force")); err != nil {
+		return err
+	}
+
+	h.presenter.Success("Wrote %s for workflow %s", outputFile, output.WorkflowName)
+	h.renderInputs(output.Inputs)
+	h.renderNextSteps(workflowFile, outputFile, output.Inputs)
+	return nil
+}
+
+// writeTemplate writes the template, refusing to clobber an existing file
+// unless asked: a filled-in inputs file is expensive to lose.
+func writeTemplate(path string, content []byte, force bool) error {
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("%s already exists (use --force to overwrite)", path)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to check %s: %w", path, err)
+		}
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return nil
+}
+
+// renderInputs explains every input, including the optional ones left out of
+// the template — the teaching moment of the command.
+func (h *ScaffoldHandler) renderInputs(inputs []wdl.InputSpec) {
+	if len(inputs) == 0 {
+		h.presenter.Info("This workflow declares no inputs.")
+		return
+	}
+
+	h.presenter.Newline()
+	table := h.presenter.NewTable([]string{"INPUT", "TYPE", "REQUIRED", "DEFAULT", "DESCRIPTION"})
+	for _, in := range inputs {
+		required := "no"
+		if in.Required() {
+			required = "yes"
+		}
+		_ = table.Append([]string{in.Name, in.Type, required, in.Default, in.Description})
+	}
+	_ = table.Render()
+}
+
+func (h *ScaffoldHandler) renderNextSteps(workflowFile, outputFile string, inputs []wdl.InputSpec) {
+	required := 0
+	for _, in := range inputs {
+		if in.Required() {
+			required++
+		}
+	}
+
+	h.presenter.Newline()
+	h.presenter.Title("Next steps")
+	h.presenter.Println(fmt.Sprintf("  1. Replace the %d placeholder value(s) in %s", required, outputFile))
+	h.presenter.Println(fmt.Sprintf("  2. pumbaa workflow preflight -w %s -i %s", workflowFile, outputFile))
+	h.presenter.Println(fmt.Sprintf("  3. pumbaa workflow submit -w %s -i %s", workflowFile, outputFile))
+}

--- a/internal/interfaces/cli/handler/submit.go
+++ b/internal/interfaces/cli/handler/submit.go
@@ -3,6 +3,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -58,6 +59,10 @@ func (h *SubmitHandler) Command() *cli.Command {
 				Aliases: []string{"l"},
 				Usage:   "[optional] Labels to attach to the workflow (format: key=value)",
 			},
+			&cli.BoolFlag{
+				Name:  "skip-preflight",
+				Usage: "[optional] Submit without checking the workflow and inputs first",
+			},
 		},
 		Action: h.handle,
 	}
@@ -83,10 +88,20 @@ func (h *SubmitHandler) handle(c *cli.Context) error {
 		OptionsFile:      c.String("options"),
 		DependenciesFile: c.String("dependencies"),
 		Labels:           labels,
+		SkipPreflight:    c.Bool("skip-preflight"),
 	}
 
 	output, err := h.useCase.Execute(ctx, input)
 	if err != nil {
+		// Preflight found problems: show the whole checklist rather than a
+		// single message, so everything can be fixed in one pass.
+		var preflightErr *workflow.PreflightFailedError
+		if errors.As(err, &preflightErr) {
+			renderPreflightReport(h.presenter, preflightErr.Report)
+			h.presenter.Newline()
+			h.presenter.Info("Nothing was submitted. Fix the problems above, or use --skip-preflight to submit anyway.")
+			return cli.Exit("", 1)
+		}
 		h.presenter.Error("Failed to submit workflow: %v", err)
 		return err
 	}

--- a/internal/interfaces/cli/handler/submit.go
+++ b/internal/interfaces/cli/handler/submit.go
@@ -106,9 +106,29 @@ func (h *SubmitHandler) handle(c *cli.Context) error {
 		return err
 	}
 
+	// Confirm preflight ran: silent success would make the feature look like
+	// it never happened, and would swallow non-blocking warnings.
+	reportPreflightBeforeSubmit(h.presenter, output.Preflight, c.Bool("skip-preflight"))
+
 	h.presenter.Success("Workflow submitted successfully!")
 	h.presenter.KeyValue("Workflow ID", output.WorkflowID)
 	h.presenter.KeyValue("Status", h.presenter.StatusColor(output.Status))
 
 	return nil
+}
+
+// reportPreflightBeforeSubmit shows the outcome of the pre-submission checks:
+// the full checklist when there are warnings worth seeing, a one-line
+// confirmation when everything was clean, and a note when it was skipped.
+func reportPreflightBeforeSubmit(p *presenter.Presenter, report *workflow.PreflightReport, skipped bool) {
+	if skipped || report == nil {
+		p.Info("Preflight skipped.")
+		return
+	}
+	if _, warnCount := report.Counts(); warnCount > 0 {
+		renderPreflightReport(p, report)
+		p.Newline()
+		return
+	}
+	p.Success("Preflight passed.")
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -67,6 +67,28 @@ status, failures, logs, outputs, or runtime metadata.
 
 ---
 
+## 1b. Prepare a Submission (before running a new workflow)
+
+Use when the user wants to run a workflow they have not submitted yet, or asks
+what a workflow needs. Files are read from the working directory pumbaa was
+launched in.
+
+- action="scaffold"
+  Show a workflow's declared inputs and an inputs-JSON template to fill in.
+  Answers "what does this workflow need to run?"
+  Required: workflow_file (a .wdl path). Optional: include_optional
+
+- action="preflight"
+  Check an inputs JSON against a WDL before submitting: required inputs
+  present, well-typed, file paths existing.
+  Required: workflow_file. Optional: inputs_file
+
+To help a newcomer submit: scaffold → (they fill the template; write_file can
+save it) → preflight → tell them to run "pumbaa workflow submit". Submitting
+itself is a CLI action, not a tool.
+
+---
+
 ## 2. Files (Google Cloud Storage)
 
 Use **only** to read real files produced by executions.
@@ -115,6 +137,7 @@ Use **only** to understand or explain WDL definitions.
 - “What does this task do / inputs / command?” → **WDL**
 - “Why did it fail?” → failures → read_log (metadata only as last resort: it can be huge)
 - “Why is it expensive / how many preemptions?” → cost / preemption
+- “What inputs does this workflow need / how do I run it?” → scaffold, then preflight
 - Failure debugging:
   1. failures (grouped root causes + stderr paths)
   2. read_log (tail of the failing task's stderr)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Dashboard: features/dashboard.md
     - Debug View: features/debug.md
   - CLI Commands:
+    - Prepare a Submission: features/guided-submit.md
     - Submit Workflow: features/submit.md
     - Query Workflows: features/query.md
     - Workflow Metadata: features/metadata.md
@@ -61,6 +62,7 @@ nav:
   - Development:
     - Contributing: contributing.md
     - Architecture: ARCHITECTURE.md
+    - "Design: guided submit": design/guided-submit.md
     - Testing Guidelines: testing-guidelines.md
 
 markdown_extensions:

--- a/pkg/wdl/dependencies.go
+++ b/pkg/wdl/dependencies.go
@@ -1,0 +1,147 @@
+package wdl
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DependencyReport is the result of checking a workflow's imports against a
+// dependencies zip.
+type DependencyReport struct {
+	// ZipRead reports whether the zip could be read. When false, only a
+	// warning is present and the check is inconclusive.
+	ZipRead bool
+	// WDLFiles is the number of .wdl entries found in the zip.
+	WDLFiles int
+	Findings []Finding
+}
+
+// HasErrors reports whether any import fails to resolve.
+func (r *DependencyReport) HasErrors() bool {
+	for _, f := range r.Findings {
+		if f.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckDependencies verifies that every WDL import — in the main workflow and,
+// transitively, in each WDL inside the dependencies zip — resolves to a file
+// present in the zip. It is what catches "you forgot to bundle a file" before
+// Cromwell fails to parse the workflow.
+//
+// Matching is by basename, the convention `pumbaa bundle` produces and the
+// most lenient one: an import resolves as long as a file with that name is in
+// the zip, regardless of directory layout. This keeps the check from blocking
+// a valid submission over a structural difference, while still catching a
+// genuinely missing file. Remote (http/https) imports are left to Cromwell.
+//
+// It performs no IO: the zip is passed as bytes.
+func CheckDependencies(mainSource, zipData []byte) *DependencyReport {
+	report := &DependencyReport{}
+
+	entries, err := readZipWDL(zipData)
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("could not read the dependencies zip, so imports were not checked: %v", err),
+		})
+		return report
+	}
+	report.ZipRead = true
+	report.WDLFiles = len(entries)
+
+	available := make(map[string]bool, len(entries))
+	for name := range entries {
+		available[filepath.Base(name)] = true
+	}
+
+	// The main WDL is submitted alongside the zip; its imports resolve
+	// against the zip's contents.
+	report.Findings = append(report.Findings, unresolvedImports("the workflow", mainSource, available)...)
+
+	// Each bundled WDL may import other bundled files (transitive deps).
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		report.Findings = append(report.Findings, unresolvedImports(filepath.Base(name), entries[name], available)...)
+	}
+
+	return report
+}
+
+// unresolvedImports returns a finding for each non-remote import in source
+// whose target is not among the available files.
+func unresolvedImports(importer string, source []byte, available map[string]bool) []Finding {
+	var findings []Finding
+	seen := make(map[string]bool)
+	for _, imp := range extractImportPaths(source) {
+		if isRemoteImport(imp) {
+			continue
+		}
+		base := filepath.Base(imp)
+		if available[base] || seen[base] {
+			continue
+		}
+		seen[base] = true
+		findings = append(findings, Finding{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("%s imports %q, which is not in the dependencies zip", importer, imp),
+		})
+	}
+	return findings
+}
+
+// extractImportPaths pulls the import targets out of WDL source with the same
+// regex the bundler uses, so it is robust to WDL this parser cannot fully read.
+func extractImportPaths(source []byte) []string {
+	matches := importRegex.FindAllStringSubmatch(string(source), -1)
+	paths := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) >= 2 {
+			paths = append(paths, m[1])
+		}
+	}
+	return paths
+}
+
+// isRemoteImport reports whether an import points at a URL rather than a file
+// expected in the zip.
+func isRemoteImport(path string) bool {
+	return strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://")
+}
+
+// readZipWDL reads the .wdl entries of a zip into memory, keyed by their name
+// in the archive.
+func readZipWDL(data []byte) (map[string][]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+	entries := make(map[string][]byte)
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() || !strings.EqualFold(filepath.Ext(f.Name), ".wdl") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, fmt.Errorf("could not open %s in the zip: %w", f.Name, err)
+		}
+		content, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("could not read %s in the zip: %w", f.Name, err)
+		}
+		entries[f.Name] = content
+	}
+	return entries, nil
+}

--- a/pkg/wdl/dependencies_test.go
+++ b/pkg/wdl/dependencies_test.go
@@ -1,0 +1,167 @@
+package wdl
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// makeZip builds an in-memory zip from name→content pairs.
+func makeZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+const mainImports = `version 1.0
+import "module1.wdl"
+import "sub.wdl"
+workflow Hello { call sub.Sub {} }
+`
+
+// sub.wdl pulls in module2.wdl — a transitive dependency of the main workflow.
+const subImportsModule2 = `version 1.0
+import "module2.wdl"
+workflow Sub {}
+`
+
+func TestCheckDependenciesAllPresent(t *testing.T) {
+	zipData := makeZip(t, map[string]string{
+		"module1.wdl": "version 1.0\ntask t1 {}\n",
+		"sub.wdl":     subImportsModule2,
+		"module2.wdl": "version 1.0\ntask t2 {}\n",
+	})
+
+	report := CheckDependencies([]byte(mainImports), zipData)
+
+	if !report.ZipRead {
+		t.Fatal("zip should have been read")
+	}
+	if report.WDLFiles != 3 {
+		t.Errorf("WDLFiles = %d, want 3", report.WDLFiles)
+	}
+	if report.HasErrors() || len(report.Findings) != 0 {
+		t.Errorf("a complete bundle should pass: %+v", report.Findings)
+	}
+}
+
+func TestCheckDependenciesMissingDirectImport(t *testing.T) {
+	// sub.wdl is not bundled, though the main workflow imports it.
+	zipData := makeZip(t, map[string]string{
+		"module1.wdl": "version 1.0\ntask t1 {}\n",
+	})
+
+	report := CheckDependencies([]byte(mainImports), zipData)
+
+	if !report.HasErrors() {
+		t.Fatalf("a missing direct import must be an error: %+v", report.Findings)
+	}
+	if len(report.Findings) != 1 || !strings.Contains(report.Findings[0].Message, "sub.wdl") {
+		t.Errorf("finding should name the missing import: %+v", report.Findings)
+	}
+	if !strings.Contains(report.Findings[0].Message, "the workflow imports") {
+		t.Errorf("finding should attribute it to the main workflow: %q", report.Findings[0].Message)
+	}
+}
+
+func TestCheckDependenciesMissingTransitiveImport(t *testing.T) {
+	// The main workflow's direct imports are present, but sub.wdl needs
+	// module2.wdl, which was forgotten. Cromwell would fail; preflight must
+	// catch it.
+	zipData := makeZip(t, map[string]string{
+		"module1.wdl": "version 1.0\ntask t1 {}\n",
+		"sub.wdl":     subImportsModule2,
+	})
+
+	report := CheckDependencies([]byte(mainImports), zipData)
+
+	if !report.HasErrors() {
+		t.Fatalf("a missing transitive import must be an error: %+v", report.Findings)
+	}
+	msg := report.Findings[0].Message
+	if !strings.Contains(msg, "module2.wdl") || !strings.Contains(msg, "sub.wdl") {
+		t.Errorf("finding should name both the missing file and its importer: %q", msg)
+	}
+}
+
+func TestCheckDependenciesIgnoresRemoteImports(t *testing.T) {
+	main := `version 1.0
+import "https://example.com/lib.wdl"
+import "local.wdl"
+workflow W {}
+`
+	zipData := makeZip(t, map[string]string{"local.wdl": "version 1.0\ntask t {}\n"})
+
+	report := CheckDependencies([]byte(main), zipData)
+
+	if report.HasErrors() {
+		t.Errorf("remote imports are left to Cromwell, not flagged: %+v", report.Findings)
+	}
+}
+
+func TestCheckDependenciesMatchesByBasename(t *testing.T) {
+	// The import carries a path; the bundle flattens to a basename. Matching
+	// by basename must still resolve it, so a valid bundle is not blocked.
+	main := `version 1.0
+import "tasks/module1.wdl"
+workflow W {}
+`
+	zipData := makeZip(t, map[string]string{"module1.wdl": "version 1.0\ntask t {}\n"})
+
+	report := CheckDependencies([]byte(main), zipData)
+
+	if report.HasErrors() {
+		t.Errorf("a pathed import should resolve to the flattened basename: %+v", report.Findings)
+	}
+}
+
+func TestCheckDependenciesUnreadableZipIsWarning(t *testing.T) {
+	report := CheckDependencies([]byte(mainImports), []byte("this is not a zip"))
+
+	if report.ZipRead {
+		t.Error("an unreadable zip should be recorded as not read")
+	}
+	if report.HasErrors() {
+		t.Errorf("an unreadable zip must not block (Cromwell decides): %+v", report.Findings)
+	}
+	if len(report.Findings) != 1 || report.Findings[0].Severity != SeverityWarning {
+		t.Errorf("expected a single warning, got %+v", report.Findings)
+	}
+}
+
+func TestCheckDependenciesReportsEachMissingOnce(t *testing.T) {
+	// Two files import the same missing helper; report it once per importer,
+	// not once per import line.
+	main := `version 1.0
+import "a.wdl"
+import "a.wdl"
+workflow W {}
+`
+	zipData := makeZip(t, map[string]string{"other.wdl": "version 1.0\ntask t {}\n"})
+
+	report := CheckDependencies([]byte(main), zipData)
+
+	count := 0
+	for _, f := range report.Findings {
+		if strings.Contains(f.Message, "a.wdl") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicate imports of the same file should report once, got %d: %+v", count, report.Findings)
+	}
+}

--- a/pkg/wdl/inputs.go
+++ b/pkg/wdl/inputs.go
@@ -1,0 +1,249 @@
+package wdl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/lmtani/pumbaa/pkg/wdl/ast"
+)
+
+// PlaceholderPrefix marks a scaffolded value the user still has to fill in.
+// It is deliberately detectable so preflight can tell "template not filled"
+// apart from a genuine value.
+const PlaceholderPrefix = "<FILL:"
+
+// InputSpec describes one workflow input as declared in the WDL.
+type InputSpec struct {
+	Name        string // Qualified as Cromwell expects it: "workflow.input"
+	Type        string // Rendered WDL type: "File", "Array[File]+", "Int?"
+	Optional    bool   // Declared with a "?" suffix
+	Default     string // Rendered default expression, empty when unbound
+	Description string // From the workflow's parameter_meta, when documented
+}
+
+// Required reports whether the input must be provided: no "?" and no default.
+func (s InputSpec) Required() bool {
+	return !s.Optional && s.Default == ""
+}
+
+// WorkflowInputs returns the declared inputs of the workflow in the document,
+// in declaration order. Returns nil when the source has no workflow.
+func WorkflowInputs(source []byte) ([]InputSpec, error) {
+	doc, err := ParseBytes(source)
+	if err != nil {
+		return nil, err
+	}
+	if doc.Workflow == nil {
+		return nil, nil
+	}
+	return workflowInputSpecs(doc.Workflow), nil
+}
+
+func workflowInputSpecs(wf *ast.Workflow) []InputSpec {
+	specs := make([]InputSpec, 0, len(wf.Inputs))
+	for _, in := range wf.Inputs {
+		if in == nil || in.Type == nil {
+			continue
+		}
+		specs = append(specs, InputSpec{
+			Name:        wf.Name + "." + in.Name,
+			Type:        in.Type.String(),
+			Optional:    in.Type.Optional,
+			Default:     renderExpression(in.Expression),
+			Description: parameterMetaDescription(wf.ParameterMeta, in.Name),
+		})
+	}
+	return specs
+}
+
+// parameterMetaDescription extracts an input's documentation from
+// parameter_meta, which WDL allows as either a bare string or an object
+// carrying a "description" (or "help") field.
+func parameterMetaDescription(meta map[string]any, name string) string {
+	raw, ok := meta[name]
+	if !ok {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return v
+	case map[string]any:
+		for _, key := range []string{"description", "help"} {
+			if s, ok := v[key].(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// renderExpression renders a default expression for display. Only literal
+// forms are rendered; anything computed (function calls, references) renders
+// as empty, which keeps "has a default" honest for scaffolding purposes.
+func renderExpression(e ast.Expression) string {
+	v, ok := literalValue(e)
+	if !ok {
+		return ""
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// literalValue extracts the Go value of a literal expression, reporting
+// whether the expression was a literal at all.
+func literalValue(e ast.Expression) (any, bool) {
+	switch v := e.(type) {
+	case nil:
+		return nil, false
+	case *ast.StringLiteral:
+		return v.Value, true
+	case *ast.Literal:
+		if v.Value == nil {
+			// Both "None" and unparsed expressions land here; treat as
+			// no usable literal.
+			return nil, false
+		}
+		return v.Value, true
+	case *ast.ArrayLiteral:
+		items := make([]any, 0, len(v.Elements))
+		for _, el := range v.Elements {
+			item, ok := literalValue(el)
+			if !ok {
+				return nil, false
+			}
+			items = append(items, item)
+		}
+		return items, true
+	}
+	return nil, false
+}
+
+// Scaffold is a generated inputs template together with the declarations it
+// was generated from.
+type Scaffold struct {
+	WorkflowName string
+	// Template is the inputs JSON to fill in.
+	Template []byte
+	// Inputs describes every declared input, including the optional ones
+	// left out of the template, so callers can explain them to the user.
+	Inputs []InputSpec
+}
+
+// ScaffoldOptions controls how the inputs template is rendered.
+type ScaffoldOptions struct {
+	// IncludeOptional adds optional inputs, rendered with their default
+	// value (or null when the default is not a literal).
+	IncludeOptional bool
+}
+
+// ScaffoldInputs renders an inputs JSON template for the workflow, with
+// required inputs first, in declaration order. Values of required inputs are
+// placeholders (see PlaceholderPrefix) carrying the type and, when the WDL
+// documents it, the input's description.
+func ScaffoldInputs(source []byte, opts ScaffoldOptions) (*Scaffold, error) {
+	doc, err := ParseBytes(source)
+	if err != nil {
+		return nil, err
+	}
+	if doc.Workflow == nil {
+		return nil, fmt.Errorf("no workflow found in the WDL (only tasks?); nothing to scaffold")
+	}
+
+	scaffold := &Scaffold{WorkflowName: doc.Workflow.Name}
+	specs := workflowInputSpecs(doc.Workflow)
+	scaffold.Inputs = specs
+	if len(specs) == 0 {
+		scaffold.Template = []byte("{}\n")
+		return scaffold, nil
+	}
+
+	type entry struct {
+		name  string
+		value any
+	}
+	var entries []entry
+
+	for _, s := range specs {
+		if s.Required() {
+			entries = append(entries, entry{name: s.Name, value: placeholderFor(s)})
+		}
+	}
+	if opts.IncludeOptional {
+		for _, s := range specs {
+			if s.Required() {
+				continue
+			}
+			entries = append(entries, entry{name: s.Name, value: defaultOrNull(s)})
+		}
+	}
+
+	// Rendered by hand: a Go map would lose the declaration order that makes
+	// the template readable.
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	for i, e := range entries {
+		key, err := encodeJSON(e.name)
+		if err != nil {
+			return nil, err
+		}
+		value, err := encodeJSON(e.value)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(&buf, "  %s: %s", key, value)
+		if i < len(entries)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString("}\n")
+
+	scaffold.Template = buf.Bytes()
+	return scaffold, nil
+}
+
+// encodeJSON marshals a value without HTML escaping, which would turn the
+// placeholder's angle brackets into unreadable < sequences.
+func encodeJSON(v any) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return "", err
+	}
+	return strings.TrimRight(buf.String(), "\n"), nil
+}
+
+// placeholderFor builds the sentinel value for a required input.
+func placeholderFor(s InputSpec) string {
+	p := PlaceholderPrefix + " " + s.Type
+	if s.Description != "" {
+		p += " — " + s.Description
+	}
+	return p + ">"
+}
+
+// defaultOrNull renders an optional input's value: its literal default when
+// it has one, null otherwise (which means "not provided" to Cromwell).
+func defaultOrNull(s InputSpec) any {
+	if s.Default == "" {
+		return nil
+	}
+	var v any
+	if err := json.Unmarshal([]byte(s.Default), &v); err != nil {
+		return nil
+	}
+	return v
+}
+
+// IsPlaceholder reports whether a JSON value is a scaffolded placeholder the
+// user has not replaced yet.
+func IsPlaceholder(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.HasPrefix(s, PlaceholderPrefix)
+}

--- a/pkg/wdl/inputs_check.go
+++ b/pkg/wdl/inputs_check.go
@@ -1,0 +1,325 @@
+package wdl
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/lmtani/pumbaa/pkg/wdl/ast"
+)
+
+// Severity classifies a finding. Errors describe things Cromwell will
+// reject; warnings describe things that are suspicious but may well be
+// valid, since Cromwell coerces some types and this parser does not model
+// every WDL construct.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Finding is a single problem found while checking an inputs JSON against
+// the workflow that consumes it.
+type Finding struct {
+	Severity Severity
+	Input    string // Qualified input name, empty when not input-specific
+	Message  string
+}
+
+// FileRef is a File-typed value found in the inputs, for callers that can
+// verify whether the path actually exists.
+type FileRef struct {
+	Input string
+	Path  string
+}
+
+// InputsReport is the result of checking an inputs JSON against a WDL.
+type InputsReport struct {
+	WorkflowName string
+	// Parsed reports whether the WDL could be parsed. When false, only the
+	// parse warning is present: Cromwell remains the authority on WDL that
+	// this parser cannot read.
+	Parsed   bool
+	Findings []Finding
+	Files    []FileRef
+}
+
+// HasErrors reports whether any finding would make Cromwell reject the run.
+func (r *InputsReport) HasErrors() bool {
+	for _, f := range r.Findings {
+		if f.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckInputs checks an inputs JSON against the workflow declared in the WDL
+// source: required inputs present, no placeholders left from scaffolding,
+// values plausible for their declared types, and no undeclared keys. It also
+// returns every File-typed path, so callers can verify their existence.
+//
+// It performs no IO and never fails on WDL it cannot parse — that case is
+// reported as a warning and left to Cromwell.
+func CheckInputs(source, inputsJSON []byte) *InputsReport {
+	report := &InputsReport{}
+
+	doc, err := ParseBytes(source)
+	if err != nil || doc.Workflow == nil {
+		report.Findings = append(report.Findings, Finding{
+			Severity: SeverityWarning,
+			Message:  "could not parse the WDL locally, so input checks were skipped (Cromwell will validate it)",
+		})
+		return report
+	}
+	report.Parsed = true
+	report.WorkflowName = doc.Workflow.Name
+
+	provided, err := parseInputValues(inputsJSON)
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("inputs file is not valid JSON: %v", err),
+		})
+		return report
+	}
+
+	declared := make(map[string]*ast.Declaration, len(doc.Workflow.Inputs))
+	prefix := doc.Workflow.Name + "."
+	for _, in := range doc.Workflow.Inputs {
+		if in != nil && in.Type != nil {
+			declared[prefix+in.Name] = in
+		}
+	}
+
+	for _, spec := range workflowInputSpecs(doc.Workflow) {
+		value, ok := provided[spec.Name]
+		if !ok {
+			if spec.Required() {
+				report.Findings = append(report.Findings, Finding{
+					Severity: SeverityError,
+					Input:    spec.Name,
+					Message:  fmt.Sprintf("required input is missing (type %s)", spec.Type),
+				})
+			}
+			continue
+		}
+		if IsPlaceholder(value) {
+			report.Findings = append(report.Findings, Finding{
+				Severity: SeverityError,
+				Input:    spec.Name,
+				Message:  fmt.Sprintf("still holds the scaffold placeholder — replace it with a value of type %s", spec.Type),
+			})
+			continue
+		}
+		decl := declared[spec.Name]
+		report.Findings = append(report.Findings, checkValue(spec.Name, decl.Type, value)...)
+		report.Files = append(report.Files, collectFiles(spec.Name, decl.Type, value)...)
+	}
+
+	for name := range provided {
+		if _, ok := declared[name]; ok {
+			continue
+		}
+		report.Findings = append(report.Findings, Finding{
+			Severity: SeverityWarning,
+			Input:    name,
+			Message:  "not declared by this workflow — check for a typo (subworkflow-qualified inputs are not modelled here)",
+		})
+	}
+
+	sortFindings(report.Findings)
+	return report
+}
+
+// checkValue compares a JSON value against a declared WDL type. It only
+// reports an error when no reasonable coercion exists: being wrong here
+// would block a valid submission, which is worse than staying quiet.
+func checkValue(name string, t *ast.Type, value any) []Finding {
+	if t == nil {
+		return nil
+	}
+	if value == nil {
+		if t.Optional {
+			return nil
+		}
+		return []Finding{{
+			Severity: SeverityError,
+			Input:    name,
+			Message:  fmt.Sprintf("is null, but %s is required", t.String()),
+		}}
+	}
+
+	switch t.Base {
+	case "Int":
+		return checkNumber(name, t, value, true)
+	case "Float":
+		return checkNumber(name, t, value, false)
+	case "Boolean":
+		switch v := value.(type) {
+		case bool:
+			return nil
+		case string:
+			if v == "true" || v == "false" {
+				return warn(name, "is the string %q where Boolean is expected", v)
+			}
+		}
+		return mismatch(name, t, value)
+	case "String":
+		switch value.(type) {
+		case string:
+			return nil
+		case float64, bool:
+			return warn(name, "is a %s where String is expected; Cromwell may coerce it", jsonKind(value))
+		}
+		return mismatch(name, t, value)
+	case "File", "Directory":
+		if s, ok := value.(string); ok {
+			if strings.TrimSpace(s) == "" {
+				return []Finding{{Severity: SeverityError, Input: name, Message: "is an empty path"}}
+			}
+			return nil
+		}
+		return mismatch(name, t, value)
+	case "Array":
+		items, ok := value.([]any)
+		if !ok {
+			return mismatch(name, t, value)
+		}
+		if t.NonEmpty && len(items) == 0 {
+			return []Finding{{
+				Severity: SeverityError,
+				Input:    name,
+				Message:  fmt.Sprintf("is empty, but %s requires at least one element", t.String()),
+			}}
+		}
+		var findings []Finding
+		for i, item := range items {
+			findings = append(findings, checkValue(fmt.Sprintf("%s[%d]", name, i), t.ArrayType, item)...)
+		}
+		return findings
+	case "Map", "Object":
+		if _, ok := value.(map[string]any); !ok {
+			return mismatch(name, t, value)
+		}
+		return nil
+	case "Pair":
+		switch value.(type) {
+		case map[string]any, []any:
+			return nil
+		}
+		return mismatch(name, t, value)
+	}
+
+	// Unknown base (custom struct types): nothing reliable to check.
+	return nil
+}
+
+// checkNumber validates Int/Float values, tolerating the coercions Cromwell
+// itself performs.
+func checkNumber(name string, t *ast.Type, value any, integral bool) []Finding {
+	switch v := value.(type) {
+	case float64:
+		if integral && v != math.Trunc(v) {
+			return []Finding{{
+				Severity: SeverityError,
+				Input:    name,
+				Message:  fmt.Sprintf("is %v, but Int expects a whole number", v),
+			}}
+		}
+		return nil
+	case string:
+		if _, err := strconv.ParseFloat(v, 64); err == nil {
+			return warn(name, "is the quoted number %q where %s is expected", v, t.String())
+		}
+	}
+	return mismatch(name, t, value)
+}
+
+func mismatch(name string, t *ast.Type, value any) []Finding {
+	return []Finding{{
+		Severity: SeverityError,
+		Input:    name,
+		Message:  fmt.Sprintf("is a %s, but %s is expected", jsonKind(value), t.String()),
+	}}
+}
+
+func warn(name, format string, args ...any) []Finding {
+	return []Finding{{Severity: SeverityWarning, Input: name, Message: fmt.Sprintf(format, args...)}}
+}
+
+// jsonKind names a decoded JSON value the way a user would describe it.
+func jsonKind(v any) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64:
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "list"
+	case map[string]any:
+		return "object"
+	}
+	return "value"
+}
+
+// collectFiles returns every File-typed path in a value, recursing into
+// arrays so scattered inputs are covered too.
+func collectFiles(name string, t *ast.Type, value any) []FileRef {
+	if t == nil || value == nil {
+		return nil
+	}
+	switch t.Base {
+	case "File", "Directory":
+		if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+			return []FileRef{{Input: name, Path: s}}
+		}
+	case "Array":
+		items, ok := value.([]any)
+		if !ok {
+			return nil
+		}
+		var refs []FileRef
+		for i, item := range items {
+			refs = append(refs, collectFiles(fmt.Sprintf("%s[%d]", name, i), t.ArrayType, item)...)
+		}
+		return refs
+	}
+	return nil
+}
+
+// parseInputValues decodes the inputs JSON into plain Go values.
+func parseInputValues(data []byte) (map[string]any, error) {
+	if len(data) == 0 {
+		return map[string]any{}, nil
+	}
+	var values map[string]any
+	if err := json.Unmarshal(data, &values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// sortFindings puts errors before warnings, keeping each group in the order
+// it was produced (declaration order for inputs).
+func sortFindings(findings []Finding) {
+	stable := make([]Finding, 0, len(findings))
+	for _, f := range findings {
+		if f.Severity == SeverityError {
+			stable = append(stable, f)
+		}
+	}
+	for _, f := range findings {
+		if f.Severity != SeverityError {
+			stable = append(stable, f)
+		}
+	}
+	copy(findings, stable)
+}

--- a/pkg/wdl/inputs_test.go
+++ b/pkg/wdl/inputs_test.go
@@ -1,0 +1,405 @@
+package wdl
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// sampleWDL exercises the input shapes that matter: required and optional,
+// defaults, compound types, and parameter_meta in both spellings.
+const sampleWDL = `version 1.0
+
+workflow AlignReads {
+    input {
+        File reads_fastq
+        Array[File]+ reference_files
+        String sample_name
+        Int threads = 4
+        Float? min_quality
+        Boolean skip_qc = false
+        File? adapters
+    }
+
+    parameter_meta {
+        reads_fastq: "Sequencing reads in FASTQ format"
+        reference_files: {description: "Reference genome and its index files"}
+    }
+
+    call align { input: reads = reads_fastq }
+}
+
+task align {
+    input { File reads }
+    command <<< echo ~{reads} >>>
+    runtime { docker: "ubuntu:22.04" }
+}
+`
+
+func specByName(t *testing.T, specs []InputSpec, name string) InputSpec {
+	t.Helper()
+	for _, s := range specs {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("input %q not found in %+v", name, specs)
+	return InputSpec{}
+}
+
+func TestWorkflowInputs(t *testing.T) {
+	specs, err := WorkflowInputs([]byte(sampleWDL))
+	if err != nil {
+		t.Fatalf("WorkflowInputs() error = %v", err)
+	}
+	if len(specs) != 7 {
+		t.Fatalf("got %d inputs, want 7: %+v", len(specs), specs)
+	}
+
+	// Declaration order is preserved and names are qualified for Cromwell.
+	if specs[0].Name != "AlignReads.reads_fastq" {
+		t.Errorf("first input = %q, want AlignReads.reads_fastq", specs[0].Name)
+	}
+
+	reads := specByName(t, specs, "AlignReads.reads_fastq")
+	if reads.Type != "File" || !reads.Required() {
+		t.Errorf("reads_fastq = %+v, want required File", reads)
+	}
+	if reads.Description != "Sequencing reads in FASTQ format" {
+		t.Errorf("parameter_meta string form not read: %q", reads.Description)
+	}
+
+	refs := specByName(t, specs, "AlignReads.reference_files")
+	if refs.Type != "Array[File]+" {
+		t.Errorf("reference_files type = %q, want Array[File]+", refs.Type)
+	}
+	if refs.Description != "Reference genome and its index files" {
+		t.Errorf("parameter_meta object form not read: %q", refs.Description)
+	}
+
+	// A default makes an input optional to provide, even without "?".
+	threads := specByName(t, specs, "AlignReads.threads")
+	if threads.Required() || threads.Default != "4" {
+		t.Errorf("threads = %+v, want not required with default 4", threads)
+	}
+
+	skip := specByName(t, specs, "AlignReads.skip_qc")
+	if skip.Default != "false" {
+		t.Errorf("skip_qc default = %q, want false", skip.Default)
+	}
+
+	// "?" without a default: not required, no default value.
+	quality := specByName(t, specs, "AlignReads.min_quality")
+	if quality.Required() || !quality.Optional || quality.Default != "" {
+		t.Errorf("min_quality = %+v, want optional with no default", quality)
+	}
+}
+
+func TestWorkflowInputsWithoutWorkflow(t *testing.T) {
+	specs, err := WorkflowInputs([]byte("version 1.0\n\ntask lonely {\n  command <<< echo hi >>>\n}\n"))
+	if err != nil {
+		t.Fatalf("WorkflowInputs() error = %v", err)
+	}
+	if specs != nil {
+		t.Errorf("a document with no workflow should yield no inputs, got %+v", specs)
+	}
+}
+
+func TestScaffoldInputsRequiredOnly(t *testing.T) {
+	sc, err := ScaffoldInputs([]byte(sampleWDL), ScaffoldOptions{})
+	if err != nil {
+		t.Fatalf("ScaffoldInputs() error = %v", err)
+	}
+	tpl := sc.Template
+	if sc.WorkflowName != "AlignReads" {
+		t.Errorf("WorkflowName = %q, want AlignReads", sc.WorkflowName)
+	}
+	if len(sc.Inputs) != 7 {
+		t.Errorf("Inputs should describe every input, got %d", len(sc.Inputs))
+	}
+
+	// Angle brackets must survive: HTML-escaped placeholders are unreadable.
+	if strings.Contains(string(tpl), "\\u003c") {
+		t.Errorf("placeholder was HTML-escaped:\n%s", tpl)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(tpl, &got); err != nil {
+		t.Fatalf("template is not valid JSON: %v\n%s", err, tpl)
+	}
+	if len(got) != 3 {
+		t.Errorf("template should hold only the 3 required inputs, got %v", got)
+	}
+	for _, name := range []string{"AlignReads.reads_fastq", "AlignReads.reference_files", "AlignReads.sample_name"} {
+		v, ok := got[name]
+		if !ok {
+			t.Fatalf("required input %q missing from template", name)
+		}
+		if !IsPlaceholder(v) {
+			t.Errorf("%s = %v, want a placeholder", name, v)
+		}
+	}
+
+	// The placeholder teaches: type and, when documented, description.
+	reads := got["AlignReads.reads_fastq"].(string)
+	if !strings.Contains(reads, "File") || !strings.Contains(reads, "Sequencing reads") {
+		t.Errorf("placeholder should carry type and description, got %q", reads)
+	}
+
+	// Declaration order survives (a Go map would have shuffled it).
+	first := strings.Index(string(tpl), "reads_fastq")
+	second := strings.Index(string(tpl), "reference_files")
+	third := strings.Index(string(tpl), "sample_name")
+	if first > second || second > third {
+		t.Errorf("template lost declaration order:\n%s", tpl)
+	}
+}
+
+func TestScaffoldInputsIncludeOptional(t *testing.T) {
+	sc, err := ScaffoldInputs([]byte(sampleWDL), ScaffoldOptions{IncludeOptional: true})
+	if err != nil {
+		t.Fatalf("ScaffoldInputs() error = %v", err)
+	}
+	tpl := sc.Template
+
+	var got map[string]any
+	if err := json.Unmarshal(tpl, &got); err != nil {
+		t.Fatalf("template is not valid JSON: %v", err)
+	}
+	if len(got) != 7 {
+		t.Fatalf("got %d inputs, want all 7: %v", len(got), got)
+	}
+	// Literal defaults are rendered as values...
+	if got["AlignReads.threads"] != float64(4) {
+		t.Errorf("threads = %v, want its default 4", got["AlignReads.threads"])
+	}
+	if got["AlignReads.skip_qc"] != false {
+		t.Errorf("skip_qc = %v, want its default false", got["AlignReads.skip_qc"])
+	}
+	// ...and optionals without a default mean "not provided".
+	if v, ok := got["AlignReads.adapters"]; !ok || v != nil {
+		t.Errorf("adapters = %v, want null", v)
+	}
+}
+
+func TestScaffoldInputsNoInputs(t *testing.T) {
+	sc, err := ScaffoldInputs([]byte("version 1.0\n\nworkflow Empty {\n}\n"), ScaffoldOptions{})
+	if err != nil {
+		t.Fatalf("ScaffoldInputs() error = %v", err)
+	}
+	if strings.TrimSpace(string(sc.Template)) != "{}" {
+		t.Errorf("template = %q, want {}", sc.Template)
+	}
+}
+
+func TestCheckInputsAcceptsValidInputs(t *testing.T) {
+	inputs := `{
+	  "AlignReads.reads_fastq": "gs://bucket/reads.fastq",
+	  "AlignReads.reference_files": ["gs://bucket/ref.fa", "gs://bucket/ref.fai"],
+	  "AlignReads.sample_name": "NA12878",
+	  "AlignReads.threads": 8,
+	  "AlignReads.min_quality": 30.5,
+	  "AlignReads.adapters": null
+	}`
+
+	report := CheckInputs([]byte(sampleWDL), []byte(inputs))
+
+	if !report.Parsed || report.WorkflowName != "AlignReads" {
+		t.Fatalf("report = %+v, want parsed AlignReads", report)
+	}
+	if len(report.Findings) != 0 {
+		t.Errorf("valid inputs produced findings: %+v", report.Findings)
+	}
+	// Every File-typed value is offered for existence checking, including
+	// each element of an Array[File].
+	if len(report.Files) != 3 {
+		t.Errorf("got %d file refs, want 3: %+v", len(report.Files), report.Files)
+	}
+	if report.Files[1].Input != "AlignReads.reference_files[0]" {
+		t.Errorf("array element refs should be indexed, got %q", report.Files[1].Input)
+	}
+}
+
+func TestCheckInputsFindsBlockingProblems(t *testing.T) {
+	inputs := `{
+	  "AlignReads.reads_fastq": "<FILL: File — Sequencing reads in FASTQ format>",
+	  "AlignReads.reference_files": "gs://bucket/ref.fa",
+	  "AlignReads.skip_qc": "yes"
+	}`
+
+	report := CheckInputs([]byte(sampleWDL), []byte(inputs))
+
+	if !report.HasErrors() {
+		t.Fatalf("expected errors, got %+v", report.Findings)
+	}
+	byInput := map[string]Finding{}
+	for _, f := range report.Findings {
+		byInput[f.Input] = f
+	}
+
+	if f := byInput["AlignReads.reads_fastq"]; f.Severity != SeverityError || !strings.Contains(f.Message, "placeholder") {
+		t.Errorf("unfilled placeholder should be an error, got %+v", f)
+	}
+	if f := byInput["AlignReads.reference_files"]; f.Severity != SeverityError || !strings.Contains(f.Message, "Array[File]+") {
+		t.Errorf("scalar for an array should be an error, got %+v", f)
+	}
+	if f := byInput["AlignReads.sample_name"]; f.Severity != SeverityError || !strings.Contains(f.Message, "missing") {
+		t.Errorf("missing required input should be an error, got %+v", f)
+	}
+	if f := byInput["AlignReads.skip_qc"]; f.Severity != SeverityError {
+		t.Errorf(`"yes" for a Boolean should be an error, got %+v`, f)
+	}
+	// Errors are listed before warnings.
+	if report.Findings[0].Severity != SeverityError {
+		t.Errorf("errors should come first, got %+v", report.Findings)
+	}
+	// A placeholder is not offered as a path to check.
+	if len(report.Files) != 0 {
+		t.Errorf("placeholders must not become file refs: %+v", report.Files)
+	}
+}
+
+func TestCheckInputsWarnsWithoutBlocking(t *testing.T) {
+	// Each of these is suspicious but plausibly coerced by Cromwell, or
+	// simply beyond what this parser models — none may block a submission.
+	inputs := `{
+	  "AlignReads.reads_fastq": "gs://bucket/reads.fastq",
+	  "AlignReads.reference_files": ["gs://bucket/ref.fa"],
+	  "AlignReads.sample_name": "NA12878",
+	  "AlignReads.threads": "8",
+	  "AlignReads.sampleName": "typo",
+	  "AlignReads.sub.inner.x": 1
+	}`
+
+	report := CheckInputs([]byte(sampleWDL), []byte(inputs))
+
+	if report.HasErrors() {
+		t.Fatalf("coercible values and unknown keys must not block: %+v", report.Findings)
+	}
+	if len(report.Findings) != 3 {
+		t.Errorf("expected 3 warnings, got %+v", report.Findings)
+	}
+}
+
+func TestCheckInputsTypeMatrix(t *testing.T) {
+	const wdlSrc = `version 1.0
+
+workflow T {
+    input {
+        Int i
+        Float f
+        Boolean b
+        String s
+        Array[Int] nums
+        Map[String, String] m
+    }
+}
+`
+	cases := []struct {
+		name     string
+		inputs   string
+		severity Severity // "" means no finding for that input
+		input    string
+	}{
+		{"int accepts whole number", `{"T.i": 5}`, "", "T.i"},
+		{"int rejects decimal", `{"T.i": 5.5}`, SeverityError, "T.i"},
+		{"int warns on quoted number", `{"T.i": "5"}`, SeverityWarning, "T.i"},
+		{"int rejects text", `{"T.i": "many"}`, SeverityError, "T.i"},
+		{"float accepts whole number", `{"T.f": 3}`, "", "T.f"},
+		{"float accepts decimal", `{"T.f": 3.5}`, "", "T.f"},
+		{"boolean rejects number", `{"T.b": 1}`, SeverityError, "T.b"},
+		{"boolean warns on quoted bool", `{"T.b": "true"}`, SeverityWarning, "T.b"},
+		{"string warns on number", `{"T.s": 5}`, SeverityWarning, "T.s"},
+		{"string rejects list", `{"T.s": [1]}`, SeverityError, "T.s"},
+		{"array accepts list", `{"T.nums": [1, 2]}`, "", "T.nums"},
+		{"array rejects scalar", `{"T.nums": 1}`, SeverityError, "T.nums"},
+		{"array element type is checked", `{"T.nums": [1, "x"]}`, SeverityError, "T.nums[1]"},
+		{"map accepts object", `{"T.m": {"a": "b"}}`, "", "T.m"},
+		{"map rejects list", `{"T.m": [1]}`, SeverityError, "T.m"},
+		{"null rejected for required", `{"T.i": null}`, SeverityError, "T.i"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			report := CheckInputs([]byte(wdlSrc), []byte(tc.inputs))
+
+			var got Finding
+			for _, f := range report.Findings {
+				// Ignore the "missing required input" noise from the inputs
+				// this case does not provide.
+				if f.Input == tc.input && !strings.Contains(f.Message, "missing") {
+					got = f
+					break
+				}
+			}
+			if got.Severity != tc.severity {
+				t.Errorf("severity for %s = %q (%s), want %q", tc.input, got.Severity, got.Message, tc.severity)
+			}
+		})
+	}
+}
+
+func TestCheckInputsNonEmptyArray(t *testing.T) {
+	report := CheckInputs([]byte(sampleWDL), []byte(`{
+	  "AlignReads.reads_fastq": "gs://b/r.fastq",
+	  "AlignReads.sample_name": "NA12878",
+	  "AlignReads.reference_files": []
+	}`))
+
+	found := false
+	for _, f := range report.Findings {
+		if f.Input == "AlignReads.reference_files" && f.Severity == SeverityError && strings.Contains(f.Message, "at least one") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Array[File]+ must reject an empty list, got %+v", report.Findings)
+	}
+}
+
+func TestCheckInputsUnparseableWDLIsAWarning(t *testing.T) {
+	report := CheckInputs([]byte("this is not WDL at all {{{"), []byte(`{"x": 1}`))
+
+	if report.Parsed {
+		t.Error("report should record that the WDL was not parsed")
+	}
+	if report.HasErrors() {
+		t.Errorf("unparseable WDL must not block submission (Cromwell decides): %+v", report.Findings)
+	}
+	if len(report.Findings) != 1 || report.Findings[0].Severity != SeverityWarning {
+		t.Errorf("expected a single warning, got %+v", report.Findings)
+	}
+}
+
+func TestCheckInputsMalformedJSON(t *testing.T) {
+	report := CheckInputs([]byte(sampleWDL), []byte(`{"AlignReads.sample_name": }`))
+
+	if !report.HasErrors() {
+		t.Fatalf("malformed inputs JSON should be an error, got %+v", report.Findings)
+	}
+	if !strings.Contains(report.Findings[0].Message, "not valid JSON") {
+		t.Errorf("error should name the problem, got %q", report.Findings[0].Message)
+	}
+}
+
+func TestCheckInputsEmptyInputsFile(t *testing.T) {
+	report := CheckInputs([]byte(sampleWDL), nil)
+
+	// All three required inputs are reported, not just the first.
+	errs := 0
+	for _, f := range report.Findings {
+		if f.Severity == SeverityError {
+			errs++
+		}
+	}
+	if errs != 3 {
+		t.Errorf("got %d errors, want one per required input: %+v", errs, report.Findings)
+	}
+}
+
+func TestScaffoldInputsWithoutWorkflowFails(t *testing.T) {
+	_, err := ScaffoldInputs([]byte("version 1.0\n\ntask lonely {\n  command <<< echo hi >>>\n}\n"), ScaffoldOptions{})
+	if err == nil {
+		t.Error("scaffolding a WDL with no workflow should fail with a clear message")
+	}
+}

--- a/pkg/wdl/validate.go
+++ b/pkg/wdl/validate.go
@@ -40,12 +40,10 @@ func ValidateInputs(wdlSource []byte, inputsJSON []byte) error {
 		return fmt.Errorf("failed to parse inputs JSON: %w", err)
 	}
 
-	prefix := doc.Workflow.Name + "."
 	var missing []string
 	for _, name := range required {
-		qualified := prefix + name
-		if _, ok := provided[qualified]; !ok {
-			missing = append(missing, qualified)
+		if _, ok := provided[name]; !ok {
+			missing = append(missing, name)
 		}
 	}
 
@@ -56,13 +54,13 @@ func ValidateInputs(wdlSource []byte, inputsJSON []byte) error {
 	return nil
 }
 
-// requiredInputNames returns the names of inputs that are required
-// (non-optional type and no default expression).
+// requiredInputNames returns the qualified names of the inputs that must be
+// provided, using the same notion of "required" as InputSpec.
 func requiredInputNames(wf *ast.Workflow) []string {
 	var names []string
-	for _, input := range wf.Inputs {
-		if input.Type != nil && !input.Type.Optional && input.Expression == nil {
-			names = append(names, input.Name)
+	for _, spec := range workflowInputSpecs(wf) {
+		if spec.Required() {
+			names = append(names, spec.Name)
 		}
 	}
 	return names


### PR DESCRIPTION
## Context and problem

Pumbaa is strong once a run exists — dashboard, watch, failure summary, cost, preemption. It is weakest exactly where newcomers to bioinformatics spend most of their pain: **getting to a correct submission in the first place**.

The loop today is: receive a WDL, hand-write an inputs file without knowing which fields are required or what types they take, guess, submit, wait, and get a failure that is about infrastructure — a typo'd key, a quoted number, a wrong cloud path — twenty minutes and a few dollars later. The only guard rail was a check for missing required inputs, buried inside submit.

The design doc for this change is included in the PR (`docs/design/guided-submit.md`); it records the layering, the severity rules and the follow-ups.

## What was done

Two commands, both built on declarations the WDL parser already produced (workflow inputs with their types, optionality, defaults and `parameter_meta` documentation — the data was there, it simply was never surfaced):

- **`workflow scaffold`** renders an inputs template from the workflow itself: required inputs first, in declaration order, each with a placeholder carrying its type and, when the WDL documents it, its description. Optional inputs are left out unless `--all` (so the file is minimal and submit-ready once filled), where they appear with their default values. Without `--output` the template goes to stdout for redirection; with it, the file is written and every input — including the omitted optionals — is explained in a table, followed by the next steps.
- **`workflow preflight`** answers "is this going to work?": Cromwell reachable, WDL parses, required inputs present, placeholders replaced, values plausible for their declared types, keys actually declared by the workflow, and every file input actually existing (metadata-only lookups, run concurrently). It reports everything at once rather than stopping at the first problem, and exits non-zero on errors so scripts and CI can gate on it.

**`submit` now runs the same checks** before sending anything and prints the same checklist when it refuses, so a broken run fails in seconds instead of minutes. `--skip-preflight` bypasses it.

The placeholders are deliberately machine-detectable, which closes the obvious trap: scaffolding a template and submitting it unedited now fails with "still holds the scaffold placeholder" instead of confusing Cromwell.

## Decisions and rationale

- **Severity is the heart of this feature.** A check that blocks a valid submission destroys the trust the feature depends on, so: WDL this parser cannot read is a *warning*, never a block (Cromwell is the authority on WDL, and our parser may lag the spec — the same philosophy the previous missing-inputs check already followed); values Cromwell coerces, such as a quoted number for an integer, *warn* rather than block; keys we do not recognize *warn*, because subworkflow-qualified inputs exist that the parser does not model.
- **"Missing" and "could not check" are different answers.** A path that does not exist is the user's problem and blocks; a path that cannot be verified — no local cloud credentials, network trouble — only warns, because Cromwell may well have access this machine does not. Distinguishing them is why a not-found sentinel returns to the ports package and both storage backends now wrap their not-found errors with it. Note the irony: the previous cleanup PR removed that error taxonomy for having no consumers. It now has one, and it is a single sentinel rather than the struct-and-constructor set that was removed.
- **Everything decidable offline stays in the WDL library**, with no IO: extraction, template rendering and the checks are pure functions over the source and the inputs JSON, so the interesting logic is trivially testable. Only server health and file existence live in the use case, behind the existing ports.
- **No new port for path existence**: the file provider's size lookup already answers "does this exist and can I read it" and uses metadata-only calls on cloud storage, so nothing is transferred.
- **The type checker is conservative by construction** — it only calls something an error when no reasonable coercion exists.

## Impacts and risks

- Behavior change in `submit`: it now blocks on problems it previously let through to Cromwell, and reports missing inputs as a full checklist instead of a single validation error. This is the point of the change, but it is a behavior change; `--skip-preflight` is the escape hatch.
- Submit gained a dependency (the preflight use case, wired by the container) and a couple of hundred milliseconds when inputs carry file paths, in exchange for not discovering a bad path after twenty minutes of compute.
- The scaffold command writes files, refusing to clobber an existing one without `--force` — a filled-in inputs file is expensive to lose.

## How to validate

- Unit tests cover the library (extraction of types/optionality/defaults/documentation, template ordering and placeholders, `--all`, and a type matrix that pins both what must be flagged and the coercions that must *not* be) and the use cases (all-green, missing input and bad path reported together, unverifiable path warning, unreachable and degraded server, skip flags, unparseable WDL, submit blocked, `--skip-preflight` bypass).
- The whole flow was exercised end to end through the built binary against a WDL with compound types and documentation: scaffold to stdout and to a file, preflight on the unedited template (three placeholder errors), on valid inputs with real files (all green), and on broken inputs (missing file error plus quoted-number and typo warnings). Submit against a closed port proved it blocks *before* contacting the server, and that `--skip-preflight` really does bypass.
- Full suite, vet and lint (enforced by CI) pass.

---

## Update: chat agent actions (follow-up, same branch)

The design doc listed exposing this through the chat agent as a follow-up; it is now included. The agent is the natural front door for a newcomer, who asks "what does this workflow need?" or "is this ready to submit?" in plain language rather than discovering a CLI flag.

Two read-only actions were added to the pumbaa tool, built on the same pure WDL functions the CLI uses so the meaningful logic cannot drift:

- **scaffold** reports a workflow's declared inputs (name, type, required, default, documentation) and the template to fill in.
- **preflight** checks an inputs JSON against a WDL — required inputs present, well-typed, file paths existing. It deliberately skips the server-reachability check the CLI does: the agent already talks to Cromwell for its other actions, so an unreachable server surfaces there anyway.

Both read local files sandboxed to the working directory pumbaa was launched in, reusing `write_file`'s boundary (extracted as `localfs.ResolveWorkingDirPath`). Respecting the established tool architecture, the handlers orchestrate over ports and domain, never the application use cases — the same shape as the existing cost/failures/preemption handlers. The container wires a file provider so preflight is available in chat; without one it is simply not registered.

Covered by unit tests (scaffold output and the sandbox rejecting `../` and absolute paths; preflight ready, missing-input-plus-bad-path, and unverifiable-path-not-fatal) and a registry-level dispatch test proving the wiring.
